### PR TITLE
Simple tests for deployed helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ upload: package ## Upload the mender helm package to the charts repository
 .PHONY: template
 template: ## Render the mender helm chart template
 	helm template $(NAME)/ -f values-enterprise.yaml > $(NAME)-$(VERSION).yaml
+
+.PHONY: test
+test: ## Run tests
+	bash tests/tests.sh

--- a/tests/test-001-wait-for-pods-to-be-ready.sh
+++ b/tests/test-001-wait-for-pods-to-be-ready.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo -n "> Waiting for all the PODs to become ready"
+
+n=0
+while [ $n -lt 60 ]; do
+    NOT_READY=$(kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready | grep -v elasticsearch-master-0 | egrep -e 'false$' | wc -l)
+    if [ $NOT_READY -eq 0 ]; then
+        echo -e "\n> PODs area ready:"
+        kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready
+        exit 0
+    fi
+    echo -n "."
+    sleep 1
+    n=$((n+1))
+done
+
+echo "PODs are not ready after $n seconds, giving up!"
+exit 1

--- a/tests/test-002-create-tenant-and-user-and-login.sh
+++ b/tests/test-002-create-tenant-and-user-and-login.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -e
+
+# create an ubuntu POD to run the tests
+TEMPNAME=`basename $0`
+TMPFILE=`mktemp` || exit 1
+cat > $TMPFILE <<EOF
+kind: Pod
+apiVersion: v1
+metadata:
+  name: ubuntu
+spec:
+  containers:
+    - name: ubuntu
+      image: ubuntu
+      command: ["/bin/bash", "-ec", "sleep 3600"]
+EOF
+kubectl apply -f "$TMPFILE"
+
+echo -n "> Waiting for the ubuntu POD to become ready"
+n=0
+while [ $n -lt 60 ]; do
+    sleep 1
+    NOT_READY=$(kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready | grep ubuntu | egrep -e 'false$' | wc -l)
+    if [ $NOT_READY -eq 0 ]; then
+        echo -e "\n> POD is ready:"
+        kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready
+        break
+    fi
+    echo -n "."
+    n=$((n+1))
+done
+
+if [ $n -ge 60 ]; then
+    echo -e "\n> POD is not ready, aborting"
+    kubectl delete -f "$TMPFILE"
+    rm "$TMPFILE"
+    exit 1
+fi
+
+# install curl
+kubectl exec ubuntu -- apt update
+kubectl exec ubuntu -- apt install curl -y
+
+# create tenant and user
+UUID=$(uuidgen)
+TENANT_NAME="demo-$UUID"
+ADMIN_USERNAME="admin-$UUID@mender.io"
+ADMIN_PASSWORD="adminadmin"
+USER_USERNAME="demo-$UUID@mender.io"
+USER_PASSWORD="demodemo"
+
+TENANTADM=$(kubectl get pods -o custom-columns=POD:metadata.name | grep tenantadm | head -n1)
+USERADM=$(kubectl get pods -o custom-columns=POD:metadata.name | grep useradm | head -n1)
+
+
+echo "> Creating a new tenant: $TENANT_NAME"
+TENANT_ID=$(kubectl exec $TENANTADM -- tenantadm create-org --name $TENANT_NAME --username "$ADMIN_USERNAME" --password "$ADMIN_PASSWORD")
+
+echo "> Creating a new user for the tenant: $USER_USERNAME / $USER_PASSWORD"
+kubectl exec $USERADM -- useradm create-user --username "$USER_USERNAME" --password "$USER_PASSWORD" --tenant-id "$TENANT_ID"
+
+# log in
+echo "> Log in with credentials"
+JWT=$(kubectl exec ubuntu -- curl -s -k https://mender-api-gateway/api/management/v1/useradm/auth/login -u $USER_USERNAME:$USER_PASSWORD -X POST -H "Content-Type: application/json" -f)
+if [ -z "$JWT" ]; then
+    echo "> Login failed, aborting"
+    kubectl delete -f "$TMPFILE"
+    rm "$TMPFILE"
+    exit 1
+fi
+echo "> JWT token: $JWT"
+
+# verify the jwt token (TENANT_ID should be inside the decoded JSON)
+if ! echo $JWT | cut -f2 -d. | base64 -Dd | grep -q $TENANT_ID; then
+    echo "> JWT token is invalid"
+    kubectl delete -f "$TMPFILE"
+    rm "$TMPFILE"
+    exit 1
+fi
+
+# get the list of deployments
+echo "> Get the list of deployments"
+RESPONSE=$(kubectl exec ubuntu -- curl -s -k https://mender-api-gateway/api/management/v1/deployments/deployments -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -f)
+echo "> Got: $RESPONSE"
+
+if [ "$RESPONSE" != "[]" ]; then
+    kubectl delete -f "$TMPFILE"
+    rm "$TMPFILE"
+    exit 1
+fi
+
+# get the list of accepted devices
+echo "> Get the list of accepted devices"
+RESPONSE=$(kubectl exec ubuntu -- curl -s -k https://mender-api-gateway/api/management/v2/devauth/devices/count?status=accepted -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" -f)
+echo "> Got: $RESPONSE"
+
+if [ "$RESPONSE" != '{"count":0}' ]; then
+    kubectl delete -f "$TMPFILE"
+    rm "$TMPFILE"
+    exit 1
+fi
+
+# clean up, remove the testing pod
+kubectl delete -f "$TMPFILE"
+rm "$TMPFILE"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+errors=0
+
+for i in tests/test-*.sh; do
+    echo "=== $i"
+    EXIT_CODE=0
+    bash $i || EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "=== PASS!"
+    else
+        echo "=== FAILED!"
+        errors=1
+    fi
+done
+
+if [ "$errors" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
You can now run `make tests` to run kubectl-based tests over a Mender
deployment in the current name space.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>