### PR TITLE
Add create-artifact-worker to the Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ $ helm install --set "usePassword=false" --name redis stable/redis
 You can create a tenant from the command line of the `tenantadm` pod; the value printed is the newly generated tenant ID:
 
 ```bash
-$ tenantadm create-org --name demo
+$ tenantadm create-org --name demo --username "admin@mender.io" --password "adminadmin"
 5dcd71624143b30050e63bed
 ```
 

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.create_artifact_worker.enabled  }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: create-artifact-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: create-artifact-worker
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: workflows
+    app.kubernetes.io/part-of: mender
+    helm.sh/chart: "{{ .Chart.Name }}"
+spec:
+  replicas: {{ .Values.create_artifact_worker.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: create-artifact-worker
+
+  # if deployment is not completed within 10 min, consider it failed,
+  # as result deployment Reason=ProgressDeadlineExceeded
+  # needs to be big enough to rollout to complete
+  progressDeadlineSeconds: 600
+
+  # Rollout upgrade one by one
+  # In this case we warranty there are always instances online.
+  # In case any issues, they will be detected early and deployment be stopped.
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: create-artifact-worker
+    spec:
+      {{- with .Values.create_artifact_worker.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: workflows
+        image: {{ .Values.create_artifact_worker.image.registry }}/{{ .Values.create_artifact_worker.image.repository }}:{{ .Values.create_artifact_worker.image.tag }}
+        imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.create_artifact_worker.resources | indent 10 }}
+
+{{- if .Values.workflows.automigrate  }}
+        command: ["workflows", "--config", "/etc/workflows/config.yaml", "worker", "--automigrate"]
+{{- else -}}
+        command: ["workflows", "--config", "/etc/workflows/config.yaml", "worker"]
+{{- end }}
+
+        # Supported configuration settings: https://github.com/mendersoftware/workflows/blob/master/config.yaml
+        # Set in order, last value for the key will be used in case duplications.
+        env:
+        - name: CREATE_ARTIFACT_GATEWAY_URL
+          value: https://{{ .Values.api_gateway.service.name }}
+        - name: CREATE_ARTIFACT_DEPLOYMENTS_URL
+          value: http://{{ .Values.deployments.service.name }}:{{ .Values.deployments.service.port }}
+        envFrom:
+        - prefix: WORKFLOWS_
+          secretRef:
+            name: mongodb-common
+
+{{- if .Values.global.image.username  }}
+      imagePullSecrets:
+      - name: docker-registry
+{{- end }}
+{{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -322,3 +322,21 @@ workflows:
     annotations: {}
     type: ClusterIP
     port: 8080
+
+create_artifact_worker:
+  enabled: true
+  automigrate: true
+  replicas: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128M
+    requests:
+      cpu: 100m
+      memory: 50M
+  affinity: {}
+  image:
+    registry: docker.io
+    repository: mendersoftware/create-artifact-worker
+    tag: master
+    imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We introduce a new Mender component, named create-artifact-worker, that requires
a new deployment in the Helm chart:

- mender-create-artifact-worker: workflows worker creating artifacts

Changelog: None

Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>