### PR TITLE
MEN-4486: [pipeline] Run tests in Hosted Mender staging cluster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,5 +33,6 @@ test_helm_chart_install:
     - build
   script:
     - tests/ci-deps-k8s.sh
+    - tests/ci-make-deps.sh
     - tests/ci-make-helm.sh
     - make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,8 +6,6 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-template-k8s-test.yml'
-  - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
 build:
@@ -25,14 +23,45 @@ build:
     paths:
       - mender-*.tgz
 
-test_helm_chart_install:
-  extends: .test_on_k8s_cluster
-  variables:
-    K8S_VERSION: "v1.16.9"
+.get_kubectl_and_tools: &get_kubectl_and_tools |
+  # Install kubectl
+  apt update && apt install -yyq curl
+  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+  chmod +x ./kubectl
+  mv ./kubectl /usr/local/bin/kubectl
+  # Install AWS CLI and aws-iam-authenticator
+  apt install -yyq awscli
+  curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator
+  chmod +x ./aws-iam-authenticator
+  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
+  # Install kubectx
+  apt install -yyq kubectx
+
+.setup_eks_cluster_staging: &setup_eks_cluster_staging |
+  # Configure AWS CLI for staging cluster
+  export AWS_ACCESS_KEY_ID=$CI_JOBS_AWS_ACCESS_KEY_ID_STAGING
+  export AWS_SECRET_ACCESS_KEY=$CI_JOBS_AWS_SECRET_ACCESS_KEY_STAGING
+  export AWS_DEFAULT_REGION=$CI_JOBS_AWS_REGION_STAGING
+  aws eks --region $CI_JOBS_AWS_REGION_STAGING update-kubeconfig --name $CI_JOBS_AWS_EKS_CLUSTER_NAME_STAGING
+  kubens mender-helm-tests
+
+test:helm_chart_install:
+  stage: test
   dependencies:
     - build
-  script:
+  image: debian:buster
+  before_script:
+    - *get_kubectl_and_tools
+    - *setup_eks_cluster_staging
+    # Install test dependencies
+    - apt install -yyq make uuid-runtime
     - tests/ci-deps-k8s.sh
+    # Clean possible leftovers from an unfinished run
+    - tests/ci-make-clean.sh || true
+  script:
     - tests/ci-make-deps.sh
     - tests/ci-make-helm.sh
     - make test
+  after_script:
+    - *setup_eks_cluster_staging
+    - tests/ci-make-clean.sh

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 NAME=mender
 VERSION=$$(grep version: $(NAME)/Chart.yaml | sed -e 's/.*: *//g' | sed -e 's/"//g')
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 Using `helm3`:
 
 ```bash
+$ make package
 $ helm install mender ./mender-2.5.0.tgz
 ```
 
 or using `helm2`:
 
 ```bash
+$ make package
 $ helm install --name mender ./mender-2.5.0.tgz
 ```
 

--- a/tests/ci-deps-k8s.sh
+++ b/tests/ci-deps-k8s.sh
@@ -11,7 +11,7 @@ chmod 755 get_helm.sh
 ./get_helm.sh
 
 log "add help repo: stable"
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 
 log "deploying dependencies: minio"

--- a/tests/ci-deps-k8s.sh
+++ b/tests/ci-deps-k8s.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-. tests/variables.sh
 . tests/functions.sh
 
 set -e
@@ -10,16 +9,14 @@ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get
 chmod 755 get_helm.sh
 ./get_helm.sh
 
-log "add help repo: stable"
+log "add helm repo: stable"
 helm repo add stable https://charts.helm.sh/stable
 helm repo update
 
-log "deploying dependencies: minio"
+log "add helm repo: minio"
 helm repo add minio https://helm.min.io/
 helm repo update
-helm install mender-minio minio/minio --version 6.0.5 --set accessKey=${MINIO_accessKey},secretKey=${MINIO_secretKey},persistence.enabled=false
 
-log "deploying dependencies: mongodb"
+log "add helm repo: mongodb"
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm install mender-mongo --set "auth.enabled=false,persistence.enabled=false" bitnami/mongodb

--- a/tests/ci-make-clean.sh
+++ b/tests/ci-make-clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+helm uninstall $(helm list -q)

--- a/tests/ci-make-deps.sh
+++ b/tests/ci-make-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. tests/variables.sh
+. tests/functions.sh
+
+set -e
+
+log "deploying dependencies: minio"
+helm install mender-minio minio/minio --version 6.0.5 --set accessKey=${MINIO_accessKey},secretKey=${MINIO_secretKey},persistence.enabled=false
+
+log "deploying dependencies: mongodb"
+helm install mender-mongo --set "auth.enabled=false,persistence.enabled=false" bitnami/mongodb

--- a/tests/ci-make-deps.sh
+++ b/tests/ci-make-deps.sh
@@ -6,7 +6,10 @@
 set -e
 
 log "deploying dependencies: minio"
-helm install mender-minio minio/minio --version 6.0.5 --set accessKey=${MINIO_accessKey},secretKey=${MINIO_secretKey},persistence.enabled=false
+helm install mender-minio minio/minio \
+    --version 6.0.5 \
+    --set resources.requests.memory=100Mi \
+    --set accessKey=${MINIO_accessKey},secretKey=${MINIO_secretKey},persistence.enabled=false
 
 log "deploying dependencies: mongodb"
 helm install mender-mongo --set "auth.enabled=false,persistence.enabled=false" bitnami/mongodb

--- a/tests/ci-make-helm.sh
+++ b/tests/ci-make-helm.sh
@@ -6,6 +6,12 @@
 set -e
 
 log "installing Mender Helm chart mender-${MENDER_HELM_CHART_VERSION}.tgz"
+
+if [ -z "$REGISTRY_MENDER_IO_USERNAME" -o -z "$REGISTRY_MENDER_IO_PASSWORD" ]; then
+    log "error: missing registry.mender.io credentials"
+    exit 1
+fi
+
 helm install mender -f mender/values.yaml -f tests/keys.yaml -f tests/values.yaml --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" mender-${MENDER_HELM_CHART_VERSION}.tgz || exit 3;
 
 log "pods:"

--- a/tests/ci-make-helm.sh
+++ b/tests/ci-make-helm.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-log "installing Mender Helm chart /builds/Northern.tech/Mender/mender-helm/mender-${MENDER_HELM_CHART_VERSION}.tgz"
-helm install mender -f mender/values.yaml -f tests/keys.yaml -f tests/values.yaml --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" /builds/Northern.tech/Mender/mender-helm/mender-${MENDER_HELM_CHART_VERSION}.tgz || exit 3;
+log "installing Mender Helm chart mender-${MENDER_HELM_CHART_VERSION}.tgz"
+helm install mender -f mender/values.yaml -f tests/keys.yaml -f tests/values.yaml --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" mender-${MENDER_HELM_CHART_VERSION}.tgz || exit 3;
 
 log "pods:"
 kubectl get pods || true

--- a/tests/ci-test-setup.sh
+++ b/tests/ci-test-setup.sh
@@ -3,7 +3,6 @@
 set -e
 
 # create an ubuntu POD to run the tests
-TEMPNAME=`basename $0`
 TMPFILE=`mktemp` || exit 1
 cat > $TMPFILE <<EOF
 kind: Pod


### PR DESCRIPTION
MEN-4486: [pipeline] Run tests in Hosted Mender staging cluster

This commit reworks the test job and the helper scripts to run the tests
in HM staging, namespace mender-helm-tests.

It assumes only one CI pipeline is running in parallel.

In addition:
* [Makefile] Set shell to /bin/bash
As sh complains on invalid syntax
* [README] Document the obvious: build before install
* [ci-deps-k8s] Update URL for stable helm repository
The googleapis.com one is deprecated and prints a warning to switch to
the new one.
* [tests/] Split ci-deps-k8s.sh into two scripts: install and deploy
So that locally we can run the deploy one assuming all dependencies are
in place.
* [ci-make-helm] Use relative path instead of hardcoded CI path
* [ci-make-helm] User friendly exit when no credentials in env
* [ci-make-deps] Limit to minio memory request to 100Mi