### PR TITLE
Remove SSL port mapping svc->pod if SSL disabled

### DIFF
--- a/mender/templates/api-gateway-svc.yaml
+++ b/mender/templates/api-gateway-svc.yaml
@@ -29,6 +29,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.api_gateway.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
+{{- if .Values.api_gateway.env.SSL }}
   - port: {{ .Values.api_gateway.service.httpsPort }}
     protocol: TCP
     targetPort: 443
@@ -36,6 +37,7 @@ spec:
     nodePort: {{ .Values.api_gateway.service.httpsNodePort }}
     {{- end }}
     name: https
+{{- end }}
   - port: {{ .Values.api_gateway.service.httpPort }}
     protocol: TCP
     targetPort: 80


### PR DESCRIPTION
If helm chart is deployed without SSL support, the api-gateway-svc mapping
of the SSL port should also be removed.

Signed-off-by: Alexandru Ionita <alexandru.ionita@gmail.com>