### PR TITLE
[pipeline] Run install test only for master jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,8 @@ build:
   kubens mender-helm-tests
 
 test:helm_chart_install:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
   stage: test
   dependencies:
     - build

--- a/tests/test-001-wait-for-pods-to-be-ready.sh
+++ b/tests/test-001-wait-for-pods-to-be-ready.sh
@@ -9,7 +9,7 @@ max_wait=512
 while [ $n -lt $max_wait ]; do
     NOT_READY=$(kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready | egrep -e 'false$' -e '<none>$' | wc -l)
     if [ $NOT_READY -eq 0 ]; then
-        echo -e "\n> PODs area ready:"
+        echo -e "\n> PODs are ready:"
         kubectl get pods -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-true:status.containerStatuses[*].ready
         exit 0
     fi


### PR DESCRIPTION
So that we can verify the code before it can access protected env variables.
