### PR TITLE
Handle no SSL termination in the api-gateway

### DIFF
--- a/mender/templates/api-gateway-configmap.yaml
+++ b/mender/templates/api-gateway-configmap.yaml
@@ -1,3 +1,5 @@
+{{ $entrypoint := ternary "https" "http" (.Values.api_gateway.env.SSL) }}
+{{ $isTls := ternary true false (.Values.api_gateway.env.SSL) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,7 +25,7 @@ data:
         # auditlogs
         #
         auditlogs:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -32,13 +34,13 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/auditlogs`)"
           service: auditlogs
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # deployments
         #
         deployments:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - devauth
           - sec-headers
@@ -49,10 +51,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments`)"
           service: deployments
-          tls: true
+          tls: {{ $isTls }}
 
         deploymentsDL:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - sec-headers
           - json-error-responder1
@@ -61,10 +63,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments/download`)"
           service: deployments
-          tls: true
+          tls: {{ $isTls }}
 
         deploymentsMgmt:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -73,22 +75,22 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/deployments`)"
           service: deployments
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # deviceauth
         #
         deviceauth:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - sec-headers
           - compression
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/authentication`)"
           service: deviceauth
-          tls: true
+          tls: {{ $isTls }}
 
         deviceauthMgmt:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -97,13 +99,13 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/devauth`)"
           service: deviceauth
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # deviceconfig
         #
         deviceconfig:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - devauth
           - sec-headers
@@ -114,10 +116,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconfig`)"
           service: deviceconfig
-          tls: true
+          tls: {{ $isTls }}
 
         deviceconfigMgmt:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -126,13 +128,13 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconfig`)"
           service: deviceconfig
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # deviceconnect
         #
         deviceconnect:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - devauth
           - sec-headers
@@ -143,10 +145,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconnect`)"
           service: deviceconnect
-          tls: true
+          tls: {{ $isTls }}
 
         deviceconnectMgmt:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -157,13 +159,13 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconnect`)"
           service: deviceconnect
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # gui
         #
         gui:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - ensure-ui-path
           - signup-redirect
@@ -176,13 +178,13 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/`)"
           service: gui
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # inventory
         #
         inventoryV1:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - devauth
           - inventoryV1-replacepathregex
@@ -194,10 +196,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/v1/inventory`)"
           service: inventory
-          tls: true
+          tls: {{ $isTls }}
 
         inventoryV2:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - devauth
           - sec-headers
@@ -208,10 +210,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/devices/v2/inventory`)"
           service: inventory
-          tls: true
+          tls: {{ $isTls }}
 
         inventoryMgmtV1:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - inventoryMgmtV1-replacepathregex
@@ -221,10 +223,10 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/v1/inventory`)"
           service: inventory
-          tls: true
+          tls: {{ $isTls }}
 
         inventoryMgmtV2:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -233,23 +235,23 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/v2/inventory`)"
           service: inventory
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # tenantadm
         #
         tenantadm:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
           - compression
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/tenantadm`)"
           service: tenantadm
-          tls: true
+          tls: {{ $isTls }}
 
         tenantadmSignup:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - sec-headers
           - compression
@@ -257,13 +259,13 @@ data:
             Method(`OPTIONS`,`POST`) && Path(`/api/management/{version:v[0-9]+}/tenantadm/tenants`) ||
             Method(`OPTIONS`,`POST`) && Path(`/api/management/{version:v[0-9]+}/tenantadm/tenants/trial`)
           service: tenantadm
-          tls: true
+          tls: {{ $isTls }}
 
         #
         # useradm
         #
         useradm:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - userauth
           - sec-headers
@@ -272,17 +274,17 @@ data:
           - json-error-responder4
           rule: "PathPrefix(`/api/management/{ver:v[0-9]+}/useradm`)"
           service: useradm
-          tls: true
+          tls: {{ $isTls }}
 
         useradmNoAuth:
-          entrypoints: https
+          entrypoints: {{ $entrypoint }}
           middlewares:
           - sec-headers
           - compression
           - json-error-responder4
           rule: "Path(`/api/management/{ver:v[0-9]+}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:v[0-9]+}/useradm/{ep:(oauth2|auth/password-reset|auth/verify-email|auth/plan-verify)}`)"
           service: useradm
-          tls: true
+          tls: {{ $isTls }}
 
       #
       # Services
@@ -343,6 +345,7 @@ data:
       # Middlewares
       #
       middlewares:
+{{ $scheme := ternary "https" "http" (.Values.api_gateway.env.SSL) }}
 
         ui-stripprefix:
           stripprefix:
@@ -350,13 +353,13 @@ data:
 
         ensure-ui-path:
           redirectregex:
-            regex: "^(https?://[^/]+)(/[a-z]*)?$"
+            regex: "^({{ $scheme }}?://[^/]+)(/[a-z]*)?$"
             replacement: "${1}/ui/"
             permanent: true
 
         signup-redirect:
           redirectregex:
-            regex: "^(https://[^/]+)/signup"
+            regex: "^({{ $scheme }}://[^/]+)/signup"
             replacement: "${1}/ui/#/signup"
 
         sec-headers:
@@ -368,7 +371,7 @@ data:
             stsIncludeSubdomains: true
             browserXssFilter: true
             customRequestHeaders:
-              "X-Forwarded-Proto": "https"
+              "X-Forwarded-Proto": "{{ $scheme }}"
 
         compression:
           compress: true
@@ -417,10 +420,11 @@ data:
             regex: "^/api/management/v1/inventory/(.*)"
             replacement: "/api/0.1.0/$1"
 
+{{- if .Values.api_gateway.env.SSL }}
     tls:
       certificates:
         - certFile: /etc/traefik/certs/cert.crt
           keyFile: /etc/traefik/certs/private.key
           stores:
             - default
-
+{{- end }}

--- a/mender/templates/api-gateway-configmap.yaml
+++ b/mender/templates/api-gateway-configmap.yaml
@@ -1,4 +1,4 @@
-{{ $entrypoint := ternary "https" "http" (.Values.api_gateway.env.SSL) }}
+{{ $scheme := ternary "https" "http" (.Values.api_gateway.env.SSL) }}
 {{ $isTls := ternary true false (.Values.api_gateway.env.SSL) }}
 apiVersion: v1
 kind: ConfigMap
@@ -25,7 +25,7 @@ data:
         # auditlogs
         #
         auditlogs:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -40,7 +40,7 @@ data:
         # deployments
         #
         deployments:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - devauth
           - sec-headers
@@ -54,7 +54,7 @@ data:
           tls: {{ $isTls }}
 
         deploymentsDL:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - sec-headers
           - json-error-responder1
@@ -66,7 +66,7 @@ data:
           tls: {{ $isTls }}
 
         deploymentsMgmt:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -81,7 +81,7 @@ data:
         # deviceauth
         #
         deviceauth:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - sec-headers
           - compression
@@ -90,7 +90,7 @@ data:
           tls: {{ $isTls }}
 
         deviceauthMgmt:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -105,7 +105,7 @@ data:
         # deviceconfig
         #
         deviceconfig:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - devauth
           - sec-headers
@@ -119,7 +119,7 @@ data:
           tls: {{ $isTls }}
 
         deviceconfigMgmt:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -134,7 +134,7 @@ data:
         # deviceconnect
         #
         deviceconnect:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - devauth
           - sec-headers
@@ -148,7 +148,7 @@ data:
           tls: {{ $isTls }}
 
         deviceconnectMgmt:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -165,7 +165,7 @@ data:
         # gui
         #
         gui:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - ensure-ui-path
           - signup-redirect
@@ -184,7 +184,7 @@ data:
         # inventory
         #
         inventoryV1:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - devauth
           - inventoryV1-replacepathregex
@@ -199,7 +199,7 @@ data:
           tls: {{ $isTls }}
 
         inventoryV2:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - devauth
           - sec-headers
@@ -213,7 +213,7 @@ data:
           tls: {{ $isTls }}
 
         inventoryMgmtV1:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - inventoryMgmtV1-replacepathregex
@@ -226,7 +226,7 @@ data:
           tls: {{ $isTls }}
 
         inventoryMgmtV2:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -241,7 +241,7 @@ data:
         # tenantadm
         #
         tenantadm:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -251,7 +251,7 @@ data:
           tls: {{ $isTls }}
 
         tenantadmSignup:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - sec-headers
           - compression
@@ -265,7 +265,7 @@ data:
         # useradm
         #
         useradm:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - userauth
           - sec-headers
@@ -277,7 +277,7 @@ data:
           tls: {{ $isTls }}
 
         useradmNoAuth:
-          entrypoints: {{ $entrypoint }}
+          entrypoints: {{ $scheme }}
           middlewares:
           - sec-headers
           - compression
@@ -345,7 +345,6 @@ data:
       # Middlewares
       #
       middlewares:
-{{ $scheme := ternary "https" "http" (.Values.api_gateway.env.SSL) }}
 
         ui-stripprefix:
           stripprefix:
@@ -420,7 +419,7 @@ data:
             regex: "^/api/management/v1/inventory/(.*)"
             replacement: "/api/0.1.0/$1"
 
-{{- if .Values.api_gateway.env.SSL }}
+{{- if $isTls }}
     tls:
       certificates:
         - certFile: /etc/traefik/certs/cert.crt

--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -56,8 +56,10 @@ spec:
             - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
+{{- if .Values.api_gateway.env.SSL }}
             - --entrypoints.http.http.redirections.entryPoint.to=https
             - --entrypoints.http.http.redirections.entryPoint.scheme=https
+{{- end }}
             - --metrics=true
             - --metrics.prometheus=true
             - --metrics.prometheus.buckets=0.100000,0.300000,1.200000,5.000000


### PR DESCRIPTION
In case no SSL termination is desired in the api-gateway, that should be
possible and the traefik configuration should be consistent with the
supplied configuration parameter `api_gateway.env.SSL`.

Signed-off-by: Alexandru Ionita <alexandru.ionita@gmail.com>