### PR TITLE
use k8s service account to access s3 bucket

### DIFF
--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -38,7 +38,9 @@ spec:
       {{- with .Values.deployments.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-
+{{- if .Values.deployments.serviceAccountName }}
+      serviceAccountName: {{ .Values.deployments.serviceAccountName }}
+{{- end }}
       containers:
       - name: deployments
 {{- if .Values.global.enterprise }}

--- a/mender/templates/secret-s3-artifacts.yaml
+++ b/mender/templates/secret-s3-artifacts.yaml
@@ -14,5 +14,11 @@ data:
   AWS_URI: {{ .Values.global.s3.AWS_URI | b64enc }}
   AWS_BUCKET: {{ .Values.global.s3.AWS_BUCKET | b64enc }}
   AWS_REGION: {{ .Values.global.s3.AWS_REGION | b64enc }}
+{{- if not .Values.global.s3.useServiceAccount }}
   AWS_AUTH_KEY: {{ .Values.global.s3.AWS_ACCESS_KEY_ID | b64enc }}
   AWS_AUTH_SECRET: {{ .Values.global.s3.AWS_SECRET_ACCESS_KEY | b64enc }}
+{{- end }}
+{{- if not .Values.global.s3.useServiceAccount }}
+  # this is required because deprecated func is used https://github.com/mendersoftware/deployments/blob/554b194e1ff389e50200644b8034bb012ede197a/s3/filestorage.go#L114
+  AWS_SDK_LOAD_CONFIG: "1"
+{{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -16,6 +16,7 @@ global:
     AWS_SECRET_ACCESS_KEY: mysecretkey
     AWS_FORCE_PATH_STYLE: "true"
     AWS_TAG_ARTIFACT: "true"
+    useServiceAccount: "false"
   smtp:
     EMAIL_SENDER: root@localhost
     SMTP_ADDRESS: smtp.mailtrap.io


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <foysal.iqbal.fb@gmail.com>

Once the K8s cluster in AWS infrastructure use can use service account to access aws resources. detail explanation is in https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/ 

In order to use K8s service account according to this need to provide `serviceAccountName` in the pod spec. User does not need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` if they want to use k8s service account. If they dont want to use service account the default behavior in chart remains as before.