### PR TITLE
Downgrade mongodb Chart version to 10.21.1, as 10.21.2 is not released

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ build:
 
 test:helm_chart_install:
   rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_COMMIT_BRANCH == "master" || $RUN_HELM_CHART_INSTALL == "true"'
   stage: test
   dependencies:
     - build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install mongodb using the official mongodb Helm chart using `helm`:
 ```bash
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
-$ helm install mongodb bitnami/mongodb --version 10.21.2 --set "image.tag=4.4.6-debian-10-r29" --set "auth.enabled=false"
+$ helm install mongodb bitnami/mongodb --version 10.21.1 --set "image.tag=4.4.6-debian-10-r29" --set "auth.enabled=false"
 ```
 
 ### Installing MinIO

--- a/tests/ci-make-clean.sh
+++ b/tests/ci-make-clean.sh
@@ -6,4 +6,4 @@ set -x
 helm uninstall $(helm list -q)
 
 # Delete other resources remaining in the namespace
-kubectl delete deployments,statefulsets,pods,jobs,cronjobs --all
+kubectl delete configmaps,deployments,statefulsets,pods,jobs,cronjobs,services --all

--- a/tests/ci-make-deps.sh
+++ b/tests/ci-make-deps.sh
@@ -14,7 +14,7 @@ helm install mender-minio minio/minio \
 
 log "deploying dependencies: mongodb"
 helm install mender-mongo bitnami/mongodb \
-    --version 10.21.2 \
+    --version 10.21.1 \
     --set "image.tag=4.4.6-debian-10-r29" \
     --set "auth.enabled=false" \
     --set "persistence.enabled=false"


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>