### PR TITLE
Use `auditlogs.enabled` as flag to enable auditlogs across services

### DIFF
--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -83,7 +83,7 @@ spec:
           value: {{ .Values.deployments.env.DEPLOYMENTS_AWS_TAG_ARTIFACT | quote }}
         - name: DEPLOYMENTS_PRESIGN_SECRET
           value: {{ .Values.deployments.env.DEPLOYMENTS_PRESIGN_SECRET | quote }}
-{{- if .Values.global.auditlogs }}
+{{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEPLOYMENTS_ENABLE_AUDIT
           value: "true"
 {{- end }}

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -72,7 +72,7 @@ spec:
 
         env:
         # Enable audit logging
-{{- if .Values.global.auditlogs }}
+{{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEVICECONFIG_ENABLE_AUDIT
           value: "true"
 {{- end }}

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -76,7 +76,7 @@ spec:
           value: "{{ .Values.global.nats.URL }}"
 
         # Enable audit logging
-{{- if .Values.global.auditlogs }}
+{{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEVICECONNECT_ENABLE_AUDIT
           value: "true"
 {{- end }}

--- a/mender/templates/gui-deploy.yaml
+++ b/mender/templates/gui-deploy.yaml
@@ -79,16 +79,16 @@ spec:
         - name: HAVE_MULTITENANT
           value: {{ .Values.global.enterprise | quote }}
         {{- end }}
-        {{- if .Values.auditlogs.enabled }}
+        {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: HAVE_AUDITLOGS
-          value: {{ .Values.auditlogs.enabled | quote }}
+          value: "true"
         {{- end }}
         {{- if .Values.deviceconnect.enabled }}
         - name: HAVE_DEVICECONNECT
-          value: {{ .Values.deviceconnect.enabled | quote }}
+          value: "true"
         {{- end }}
         {{- if .Values.deviceconfig.enabled }}
         - name: HAVE_DEVICECCONFIG
-          value: {{ .Values.deviceconfig.enabled | quote }}
+          value: "true"
         {{- end }}
 {{- end }}

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         - name: USERADM_TOTP_ISSUER
           value: {{ .Values.useradm.env.USERADM_TOTP_ISSUER | quote }}
-{{- if .Values.global.auditlogs }}
+{{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEPLOYMENTS_ENABLE_AUDIT
           value: "true"
 {{- end }}

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -59,15 +59,15 @@ spec:
         env:
         {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: HAVE_AUDITLOGS
-          value: {{ .Values.auditlogs.enabled | quote }}
+          value: "true"
         {{- end }}
         {{- if .Values.deviceconnect.enabled }}
         - name: HAVE_DEVICECONNECT
-          value: {{ .Values.deviceconnect.enabled | quote }}
+          value: "true"
         {{- end }}
         {{- if .Values.deviceconfig.enabled }}
         - name: HAVE_DEVICECONFIG
-          value: {{ .Values.deviceconfig.enabled | quote }}
+          value: "true"
         {{- end }}
 
         # Supported configuration settings: https://github.com/mendersoftware/workflows-enterprise/blob/master/config.yaml


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>