### PR TITLE
Add podAnnotations for all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.image.repository` | Docker image repository | `traefik` |
 | `api_gateway.image.tag` | Docker image tag | `v2.5` |
 | `api_gateway.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `api_gateway.podAnnotations` | add custom pod annotations | `nil` |
 | `api_gateway.replicas` | Number of replicas | `1` |
 | `api_gateway.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `api_gateway.resources.limits.cpu` | Resources CPU limit | `600m` |
@@ -207,6 +208,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.minio.enabled` | Enable routing of S3 requests to the minio service | `true` |
 | `api_gateway.minio.url` | URL of the minio service | `http://minio:9000` |
 
+
 ### Parameters: deployments
 
 The following table lists the parameters for the `deployments` component and their default values:
@@ -219,6 +221,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.image.repository` | Docker image repository | `mendersoftware/deployments-enterprise` if `global.enterprise` is true, else `mendersoftware/deployments` |
 | `deployments.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deployments.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deployments.podAnnotations` | add custom pod annotations | `nil` |
 | `deployments.replicas` | Number of replicas | `1` |
 | `deployments.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deployments.resources.limits.cpu` | Resources CPU limit | `300m` |
@@ -247,6 +250,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.image.repository` | Docker image repository | `mendersoftware/deviceauth` |
 | `device_auth.image.tag` | Docker image tag | `mender-3.1.0` |
 | `device_auth.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `device_auth.podAnnotations` | add custom pod annotations | `nil` |
 | `device_auth.replicas` | Number of replicas | `1` |
 | `device_auth.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `device_auth.resources.limits.cpu` | Resources CPU limit | `350m` |
@@ -278,6 +282,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.image.repository` | Docker image repository | `mendersoftware/gui` |
 | `gui.image.tag` | Docker image tag | `mender-3.1.0` |
 | `gui.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `gui.podAnnotations` | add custom pod annotations | `nil` |
 | `gui.replicas` | Number of replicas | `1` |
 | `gui.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `gui.resources.limits.cpu` | Resources CPU limit | `20m` |
@@ -304,6 +309,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.image.repository` | Docker image repository | `mendersoftware/inventory-enterprise` if `global.enterprise` is true, else `mendersoftware/inventory` |
 | `inventory.image.tag` | Docker image tag | `mender-3.1.0` |
 | `inventory.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `inventory.podAnnotations` | add custom pod annotations | `nil` |
 | `inventory.replicas` | Number of replicas | `1` |
 | `inventory.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `inventory.resources.limits.cpu` | Resources CPU limit | `300m` |
@@ -330,6 +336,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.image.repository` | Docker image repository | `mendersoftware/tenantadm-enterprise` |
 | `tenantadm.image.tag` | Docker image tag | `mender-3.1.0` |
 | `tenantadm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `tenantadm.podAnnotations` | add custom pod annotations | `nil` |
 | `tenantadm.replicas` | Number of replicas | `1` |
 | `tenantadm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `tenantadm.resources.limits.cpu` | Resources CPU limit | `150m` |
@@ -360,6 +367,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.image.repository` | Docker image repository | `mendersoftware/useradm-enterprise` if `global.enterprise` is true, else `mendersoftware/useradm` |
 | `useradm.image.tag` | Docker image tag | `mender-3.1.0` |
 | `useradm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `useradm.podAnnotations` | add custom pod annotations | `nil` |
 | `useradm.replicas` | Number of replicas | `1` |
 | `useradm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `useradm.resources.limits.cpu` | Resources CPU limit | `150m` |
@@ -392,6 +400,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.image.repository` | Docker image repository | `mendersoftware/workflows-enterprise` if `global.enterprise` is true, else `mendersoftware/workflows` |
 | `workflows.image.tag` | Docker image tag | `mender-3.1.0` |
 | `workflows.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `workflows.podAnnotations` | add custom pod annotations | `nil` |
 | `workflows.replicas` | Number of replicas | `1` |
 | `workflows.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `workflows.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -418,6 +427,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.image.repository` | Docker image repository | `mendersoftware/create-artifact-worker` |
 | `create_artifact_worker.image.tag` | Docker image tag | `mender-3.1.0` |
 | `create_artifact_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `create_artifact_worker.podAnnotations` | add custom pod annotations | `nil` |
 | `create_artifact_worker.replicas` | Number of replicas | `1` |
 | `create_artifact_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `create_artifact_worker.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -437,6 +447,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.image.repository` | Docker image repository | `mendersoftware/auditlogs` |
 | `auditlogs.image.tag` | Docker image tag | `mender-3.1.0` |
 | `auditlogs.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `auditlogs.podAnnotations` | add custom pod annotations | `nil` |
 | `auditlogs.replicas` | Number of replicas | `1` |
 | `auditlogs.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `auditlogs.resources.limits.cpu` | Resources CPU limit | `50m` |
@@ -464,6 +475,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.image.repository` | Docker image repository | `mendersoftware/iot_manager` |
 | `iot_manager.image.tag` | Docker image tag | `mender-3.1.0` |
 | `iot_manager.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `iot_manager.image.podAnnotations` | add custom pod annotations | `nil` |
 | `iot_manager.replicas` | Number of replicas | `1` |
 | `iot_manager.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `iot_manager.resources.limits.cpu` | Resources CPU limit | `50m` |
@@ -490,6 +502,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.image.repository` | Docker image repository | `mendersoftware/deviceconnect` |
 | `deviceconnect.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deviceconnect.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconnect.podAnnotations` | add custom pod annotations | `nil` |
 | `deviceconnect.replicas` | Number of replicas | `1` |
 | `deviceconnect.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconnect.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -516,6 +529,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.image.repository` | Docker image repository | `mendersoftware/deviceconfig` |
 | `deviceconfig.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deviceconfig.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconfig.podAnnotations` | add custom pod annotations | `nil` |
 | `deviceconfig.replicas` | Number of replicas | `1` |
 | `deviceconfig.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconfig.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -542,6 +556,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.image.repository` | Docker image repository | `mendersoftware/devicemonitor` |
 | `devicemonitor.image.tag` | Docker image tag | `mender-3.1.0` |
 | `devicemonitor.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `devicemonitor.podAnnotations` | add custom pod annotations | `nil` |
 | `devicemonitor.replicas` | Number of replicas | `1` |
 | `devicemonitor.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `devicemonitor.resources.limits.cpu` | Resources CPU limit | `100m` |

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "master"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: "3.1.0"
+version: "3.2.0"
 keywords:
 - mender
 - iot

--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.api_gateway.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: api-gateway
     spec:

--- a/mender/templates/auditlogs-deploy.yaml
+++ b/mender/templates/auditlogs-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.auditlogs.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: auditlogs
     spec:

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.create_artifact_worker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: create-artifact-worker
     spec:

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.deployments.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: deployments
     spec:

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.device_auth.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: device-auth
     spec:

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.deviceconfig.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: deviceconfig
     spec:

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.deviceconnect.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: deviceconnect
     spec:

--- a/mender/templates/devicemonitor-deploy.yaml
+++ b/mender/templates/devicemonitor-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.devicemonitor.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: devicemonitor
     spec:

--- a/mender/templates/inventory-deploy.yaml
+++ b/mender/templates/inventory-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.inventory.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: inventory
     spec:

--- a/mender/templates/iot-manager-deploy.yaml
+++ b/mender/templates/iot-manager-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.azure_iot_manager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: iot-manager
     spec:

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.tenantadm.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: tenantadm
     spec:

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -33,6 +33,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.useradm.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: useradm
     spec:

--- a/mender/templates/workflows-server-deploy.yaml
+++ b/mender/templates/workflows-server-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.workflows.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: workflows-server
     spec:

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -32,6 +32,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.workflows.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: workflows-worker
     spec:

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -29,6 +29,7 @@ global:
 
 api_gateway:
   enabled: true
+  podAnnotations: {}
   dashboard: false
   image:
     registry: docker.io
@@ -54,10 +55,12 @@ api_gateway:
     SSL: true
   minio:
     enabled: true
+    podAnnotations: {}
     url: "http://minio:9000"
 
 deployments:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -84,6 +87,7 @@ deployments:
 
 device_auth:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -114,6 +118,7 @@ device_auth:
 
 gui:
   enabled: true
+  podAnnotations: {}
   replicas: 1
   resources:
     limits:
@@ -136,6 +141,7 @@ gui:
 
 inventory:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -161,6 +167,7 @@ inventory:
 
 tenantadm:
   enabled: true
+  podAnnotations: {}
   replicas: 1
   resources:
     limits:
@@ -188,6 +195,7 @@ tenantadm:
 
 useradm:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -218,6 +226,7 @@ useradm:
 
 workflows:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -241,6 +250,7 @@ workflows:
 
 create_artifact_worker:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -259,6 +269,7 @@ create_artifact_worker:
 
 auditlogs:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -282,6 +293,7 @@ auditlogs:
 
 iot_manager:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -305,6 +317,7 @@ iot_manager:
 
 deviceconnect:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -328,6 +341,7 @@ deviceconnect:
 
 deviceconfig:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:
@@ -351,6 +365,7 @@ deviceconfig:
 
 devicemonitor:
   enabled: true
+  podAnnotations: {}
   automigrate: true
   replicas: 1
   resources:


### PR DESCRIPTION
Allows to add annotations on all mender pods.
Like `istio-injection: enabled` or `linkerd.io/inject: disabled`