### PR TITLE
Fix readiness probe for api-gateway deployment

### DIFF
--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -90,7 +90,6 @@ spec:
             port: 80
           periodSeconds: 15
           initialDelaySeconds: 5
-          periodSeconds: 5
         startupProbe:
           failureThreshold: 30
           httpGet:


### PR DESCRIPTION
The "periodseconds" field is present several times in the api-gateway readiness probe.

See [MEN-5407](https://tracker.mender.io/browse/MEN-5407)