### PR TITLE
Allow "nodeSelector" option on all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.image.repository` | Docker image repository | `traefik` |
 | `api_gateway.image.tag` | Docker image tag | `v2.5` |
 | `api_gateway.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `api_gateway.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `api_gateway.replicas` | Number of replicas | `1` |
 | `api_gateway.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `api_gateway.resources.limits.cpu` | Resources CPU limit | `600m` |
@@ -219,6 +220,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.image.repository` | Docker image repository | `mendersoftware/deployments-enterprise` if `global.enterprise` is true, else `mendersoftware/deployments` |
 | `deployments.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deployments.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deployments.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deployments.replicas` | Number of replicas | `1` |
 | `deployments.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deployments.resources.limits.cpu` | Resources CPU limit | `300m` |
@@ -247,6 +249,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.image.repository` | Docker image repository | `mendersoftware/deviceauth` |
 | `device_auth.image.tag` | Docker image tag | `mender-3.1.0` |
 | `device_auth.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `device_auth.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `device_auth.replicas` | Number of replicas | `1` |
 | `device_auth.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `device_auth.resources.limits.cpu` | Resources CPU limit | `350m` |
@@ -278,6 +281,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.image.repository` | Docker image repository | `mendersoftware/gui` |
 | `gui.image.tag` | Docker image tag | `mender-3.1.0` |
 | `gui.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `gui.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `gui.replicas` | Number of replicas | `1` |
 | `gui.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `gui.resources.limits.cpu` | Resources CPU limit | `20m` |
@@ -304,6 +308,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.image.repository` | Docker image repository | `mendersoftware/inventory-enterprise` if `global.enterprise` is true, else `mendersoftware/inventory` |
 | `inventory.image.tag` | Docker image tag | `mender-3.1.0` |
 | `inventory.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `inventory.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `inventory.replicas` | Number of replicas | `1` |
 | `inventory.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `inventory.resources.limits.cpu` | Resources CPU limit | `300m` |
@@ -330,6 +335,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.image.repository` | Docker image repository | `mendersoftware/tenantadm` |
 | `tenantadm.image.tag` | Docker image tag | `mender-3.1.0` |
 | `tenantadm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `tenantadm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `tenantadm.replicas` | Number of replicas | `1` |
 | `tenantadm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `tenantadm.resources.limits.cpu` | Resources CPU limit | `150m` |
@@ -360,6 +366,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.image.repository` | Docker image repository | `mendersoftware/useradm-enterprise` if `global.enterprise` is true, else `mendersoftware/useradm` |
 | `useradm.image.tag` | Docker image tag | `mender-3.1.0` |
 | `useradm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `useradm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `useradm.replicas` | Number of replicas | `1` |
 | `useradm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `useradm.resources.limits.cpu` | Resources CPU limit | `150m` |
@@ -391,6 +398,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.image.repository` | Docker image repository | `mendersoftware/workflows-enterprise` if `global.enterprise` is true, else `mendersoftware/workflows` |
 | `workflows.image.tag` | Docker image tag | `mender-3.1.0` |
 | `workflows.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `workflows.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `workflows.replicas` | Number of replicas | `1` |
 | `workflows.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `workflows.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -417,6 +425,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.image.repository` | Docker image repository | `mendersoftware/create-artifact-worker` |
 | `create_artifact_worker.image.tag` | Docker image tag | `mender-3.1.0` |
 | `create_artifact_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `create_artifact_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `create_artifact_worker.replicas` | Number of replicas | `1` |
 | `create_artifact_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `create_artifact_worker.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -436,6 +445,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.image.repository` | Docker image repository | `mendersoftware/auditlogs` |
 | `auditlogs.image.tag` | Docker image tag | `mender-3.1.0` |
 | `auditlogs.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `auditlogs.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `auditlogs.replicas` | Number of replicas | `1` |
 | `auditlogs.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `auditlogs.resources.limits.cpu` | Resources CPU limit | `50m` |
@@ -463,6 +473,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.image.repository` | Docker image repository | `mendersoftware/iot-manager` |
 | `iot_manager.image.tag` | Docker image tag | `mender-3.1.0` |
 | `iot_manager.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `iot_manager.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `iot_manager.replicas` | Number of replicas | `1` |
 | `iot_manager.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `iot_manager.resources.limits.cpu` | Resources CPU limit | `50m` |
@@ -489,6 +500,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.image.repository` | Docker image repository | `mendersoftware/deviceconnect` |
 | `deviceconnect.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deviceconnect.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconnect.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconnect.replicas` | Number of replicas | `1` |
 | `deviceconnect.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconnect.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -515,6 +527,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.image.repository` | Docker image repository | `mendersoftware/deviceconfig` |
 | `deviceconfig.image.tag` | Docker image tag | `mender-3.1.0` |
 | `deviceconfig.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconfig.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconfig.replicas` | Number of replicas | `1` |
 | `deviceconfig.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconfig.resources.limits.cpu` | Resources CPU limit | `100m` |
@@ -541,6 +554,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.image.repository` | Docker image repository | `mendersoftware/devicemonitor` |
 | `devicemonitor.image.tag` | Docker image tag | `mender-3.1.0` |
 | `devicemonitor.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `devicemonitor.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `devicemonitor.replicas` | Number of replicas | `1` |
 | `devicemonitor.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `devicemonitor.resources.limits.cpu` | Resources CPU limit | `100m` |

--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -109,6 +109,10 @@ spec:
           readOnly: true
 {{- end }}
 
+{{- with .Values.api_gateway.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+
       volumes:
       - name: api-gateway-traefik
         configMap:

--- a/mender/templates/auditlogs-deploy.yaml
+++ b/mender/templates/auditlogs-deploy.yaml
@@ -82,4 +82,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.auditlogs.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -72,4 +72,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.create_artifact_worker.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -106,4 +106,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.deployments.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -108,6 +108,10 @@ spec:
           secretRef:
             name: mongodb-common
 
+{{- with .Values.device_auth.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+
       volumes:
       - name: rsa
         secret:

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -92,4 +92,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.deviceconfig.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -96,4 +96,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.deviceconnect.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/devicemonitor-deploy.yaml
+++ b/mender/templates/devicemonitor-deploy.yaml
@@ -88,6 +88,10 @@ spec:
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:
-      - name: docker-registry 
+      - name: docker-registry
+{{- end }}
+
+{{- with .Values.devicemonitor.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mender/templates/gui-deploy.yaml
+++ b/mender/templates/gui-deploy.yaml
@@ -93,8 +93,13 @@ spec:
         - name: HAVE_MONITOR
           value: "true"
         {{- end }}
+
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- end }}
+
+{{- with .Values.gui.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mender/templates/inventory-deploy.yaml
+++ b/mender/templates/inventory-deploy.yaml
@@ -89,4 +89,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.inventory.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/iot-manager-deploy.yaml
+++ b/mender/templates/iot-manager-deploy.yaml
@@ -82,4 +82,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.iot_manager.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -86,6 +86,10 @@ spec:
           secretRef:
             name: mongodb-common
 
+{{- with .Values.tenantadm.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+
       volumes:
       - name: rsa
         secret:

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -109,6 +109,10 @@ spec:
             name: mongodb-common
           prefix: USERADM_
 
+{{- with .Values.useradm.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+
       volumes:
       - name: rsa
         secret:

--- a/mender/templates/workflows-server-deploy.yaml
+++ b/mender/templates/workflows-server-deploy.yaml
@@ -89,4 +89,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.workflows.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -83,4 +83,8 @@ spec:
       imagePullSecrets:
       - name: docker-registry
 {{- end }}
+
+{{- with .Values.workflows.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -306,6 +306,7 @@ iot_manager:
     repository: mendersoftware/iot-manager
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-iot-manager
     annotations: {}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -44,6 +44,7 @@ api_gateway:
       cpu: 600m
       memory: 512M
   affinity: {}
+  nodeSelector: {}
   service:
     name: mender-api-gateway
     annotations: {}
@@ -73,6 +74,7 @@ deployments:
     repository: ""
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-deployments
     annotations: {}
@@ -99,6 +101,7 @@ device_auth:
     repository: ""
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-device-auth
     annotations: {}
@@ -128,6 +131,7 @@ gui:
     repository: mendersoftware/gui
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-gui
     annotations: {}
@@ -151,6 +155,7 @@ inventory:
     repository: ""
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-inventory
     annotations: {}
@@ -175,6 +180,7 @@ tenantadm:
     repository: mendersoftware/tenantadm
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-tenantadm
     annotations: {}
@@ -203,6 +209,7 @@ useradm:
     repository: ""
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-useradm
     annotations: {}
@@ -232,6 +239,7 @@ workflows:
     repository: ""
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-workflows-server
     annotations: {}
@@ -255,6 +263,7 @@ create_artifact_worker:
     repository: mendersoftware/create-artifact-worker
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
 
 auditlogs:
   enabled: true
@@ -273,6 +282,7 @@ auditlogs:
     repository: mendersoftware/auditlogs
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-auditlogs
     annotations: {}
@@ -319,6 +329,7 @@ deviceconnect:
     repository: mendersoftware/deviceconnect
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-deviceconnect
     annotations: {}
@@ -342,6 +353,7 @@ deviceconfig:
     repository: mendersoftware/deviceconfig
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-deviceconfig
     annotations: {}
@@ -365,6 +377,7 @@ devicemonitor:
     repository: mendersoftware/devicemonitor
     tag: mender-master
     imagePullPolicy: IfNotPresent
+  nodeSelector: {}
   service:
     name: mender-devicemonitor
     annotations: {}


### PR DESCRIPTION
Allow to select the node via helm values.

This contribution allows to use this chart in Kubernetes clusters, where the default architecture is not x86_64 for the nodes.
With this change, the users will be able to select their own nodes other than the default one, which can be based on x86_64 as that is the only supported architecture as far I see.
The node selection is done based on a pattern widely used among popular helm charts.

Some examples from other helm charts:

ingress-nginx: https://github.com/kubernetes/ingress-nginx/search?q=nodeSelector
* https://github.com/kubernetes/ingress-nginx/blob/15b0aba03b700daacf0e9a3f5154ca1b9f77ee18/charts/ingress-nginx/templates/controller-deployment.yaml#L189
* https://github.com/kubernetes/ingress-nginx/blob/15b0aba03b700daacf0e9a3f5154ca1b9f77ee18/charts/ingress-nginx/templates/controller-daemonset.yaml#L191
* ...

minio: https://github.com/minio/charts/search?q=nodeSelector
* https://github.com/minio/charts/blob/a5c84bcbad884728bff5c9c23541f936d57a13b3/minio/templates/deployment.yaml#L184
* https://github.com/minio/charts/blob/a5c84bcbad884728bff5c9c23541f936d57a13b3/minio/templates/statefulset.yaml#L136
* ...

But you can see this pattern in almost all charts:
https://github.com/helm/charts/search?q=nodeSelector

I hope you will find this contribution useful!