### PR TITLE
fix: Replace Hosted Mender references with `global.url` in workflows

### DIFF
--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -57,6 +57,8 @@ spec:
         env:
         - name: WORKFLOWS_NATS_URI
           value: "{{ .Values.global.nats.URL }}"
+        - name: WORKFLOWS_MENDER_URL
+          value: "{{ .Values.global.url }}"
         - name: CREATE_ARTIFACT_GATEWAY_URL
           value: {{ .Values.global.url | default (ternary (printf "https://%s" .Values.api_gateway.service.name ) (printf "http://%s" .Values.api_gateway.service.name) (.Values.api_gateway.env.SSL)) }}
         - name: CREATE_ARTIFACT_SKIPVERIFY

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -59,6 +59,8 @@ spec:
         env:
         - name: WORKFLOWS_NATS_URI
           value: "{{ .Values.global.nats.URL }}"
+        - name: WORKFLOWS_MENDER_URL
+          value: "{{ .Values.global.url }}"
         {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: HAVE_AUDITLOGS
           value: "true"


### PR DESCRIPTION
Depends on mendersoftware/workflows-enterprise#359