### PR TITLE
feat(rate limits): set default rate limits and caching in Mender Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.env.SSL` | SSL termination flag | `true` |
 | `api_gateway.minio.enabled` | Enable routing of S3 requests to the minio service | `true` |
 | `api_gateway.minio.url` | URL of the minio service | `http://minio:9000` |
+| `api_gateway.rateLimit.average` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `100` |
+| `api_gateway.rateLimit.burst` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `100` |
+| `api_gateway.rateLimit.period` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `1s` |
+| `api_gateway.rateLimit.sourceCriterion` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `{"ipStrategy": {"depth": 1}}` |
 
 ### Parameters: deployments
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install mongodb using the official mongodb Helm chart using `helm`:
 ```bash
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
-$ helm install mongodb bitnami/mongodb --version 10.21.1 --set "image.tag=4.4.6-debian-10-r29" --set "auth.enabled=false"
+$ helm install mongodb bitnami/mongodb --version 11.1.3 --set "image.tag=4.4.13-debian-10-r29" --set "auth.enabled=false"
 ```
 
 ### Installing MinIO
@@ -45,7 +45,7 @@ You can install MinIO using the official MinIO Helm chart using `helm`:
 ```bash
 $ helm repo add minio https://helm.min.io/
 $ helm repo update
-$ helm install minio minio/minio --version 8.0.10 --set "image.tag=RELEASE.2021-02-14T04-01-33Z" --set "accessKey=myaccesskey,secretKey=mysecretkey"
+$ helm install minio minio/minio --version 8.0.10 --set "image.tag=RELEASE.2021-02-14T04-01-33Z" --set "accessKey=myaccesskey,secretKey=mysecretkey" --set "resources.requests.memory=128M"
 ```
 
 ### Installing NATS
@@ -55,7 +55,7 @@ Follow instructions from https://nats-io.github.io/k8s using `helm`:
 ```bash
 $ helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 $ helm repo update
-$ helm install nats nats/nats --version 0.8.2 --set "nats.image=nats:2.6.5-alpine" --set "nats.jetstream.enabled=true"
+$ helm install nats nats/nats --version 0.15.1 --set "nats.image=nats:2.7.4-alpine" --set "nats.jetstream.enabled=true"
 ```
 
 ## Installing the Chart

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Using `helm`:
 
 ```bash
 $ make package
-$ helm install mender ./mender-3.1.0.tgz
+$ helm install mender ./mender-3.2.1.tgz
 ```
 
 ## Introduction
@@ -63,7 +63,7 @@ $ helm install nats nats/nats --version 0.8.2 --set "nats.image=nats:2.6.5-alpin
 To install the chart with the release name `my-release` using `helm`:
 
 ```bash
-$ helm install my-release -f values.yaml ./mender-3.1.0.tgz
+$ helm install my-release -f values.yaml ./mender-3.2.1.tgz
 ```
 
 The command deploys Mender on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -165,13 +165,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install my-release \
   --set mongodbRootPassword=secretpassword,mongodbUsername=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
-  ./mender-3.1.0.tgz
+  ./mender-3.2.1.tgz
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml ./mender-3.1.0.tgz
+$ helm install --name my-release -f values.yaml ./mender-3.2.1.tgz
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -221,7 +221,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deployments.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `deployments.image.repository` | Docker image repository | `mendersoftware/deployments-enterprise` if `global.enterprise` is true, else `mendersoftware/deployments` |
-| `deployments.image.tag` | Docker image tag | `mender-3.1.0` |
+| `deployments.image.tag` | Docker image tag | `mender-3.2.1` |
 | `deployments.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deployments.replicas` | Number of replicas | `1` |
 | `deployments.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -249,7 +249,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `device_auth.image.registry` | Docker image registry | `docker.io` |
 | `device_auth.image.repository` | Docker image repository | `mendersoftware/deviceauth` |
-| `device_auth.image.tag` | Docker image tag | `mender-3.1.0` |
+| `device_auth.image.tag` | Docker image tag | `mender-3.2.1` |
 | `device_auth.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `device_auth.replicas` | Number of replicas | `1` |
 | `device_auth.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -286,7 +286,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.enabled` | Enable the component | `true` |
 | `gui.image.registry` | Docker image registry | `docker.io` |
 | `gui.image.repository` | Docker image repository | `mendersoftware/gui` |
-| `gui.image.tag` | Docker image tag | `mender-3.1.0` |
+| `gui.image.tag` | Docker image tag | `mender-3.2.1` |
 | `gui.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `gui.replicas` | Number of replicas | `1` |
 | `gui.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -312,7 +312,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `inventory.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `inventory.image.repository` | Docker image repository | `mendersoftware/inventory-enterprise` if `global.enterprise` is true, else `mendersoftware/inventory` |
-| `inventory.image.tag` | Docker image tag | `mender-3.1.0` |
+| `inventory.image.tag` | Docker image tag | `mender-3.2.1` |
 | `inventory.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `inventory.replicas` | Number of replicas | `1` |
 | `inventory.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -338,7 +338,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.enabled` | Enable the component | `true` |
 | `tenantadm.image.registry` | Docker image registry | `registry.mender.io` |
 | `tenantadm.image.repository` | Docker image repository | `mendersoftware/tenantadm` |
-| `tenantadm.image.tag` | Docker image tag | `mender-3.1.0` |
+| `tenantadm.image.tag` | Docker image tag | `mender-3.2.1` |
 | `tenantadm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `tenantadm.replicas` | Number of replicas | `1` |
 | `tenantadm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -379,7 +379,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `useradm.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `useradm.image.repository` | Docker image repository | `mendersoftware/useradm-enterprise` if `global.enterprise` is true, else `mendersoftware/useradm` |
-| `useradm.image.tag` | Docker image tag | `mender-3.1.0` |
+| `useradm.image.tag` | Docker image tag | `mender-3.2.1` |
 | `useradm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `useradm.replicas` | Number of replicas | `1` |
 | `useradm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -416,7 +416,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `workflows.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `workflows.image.repository` | Docker image repository | `mendersoftware/workflows-enterprise` if `global.enterprise` is true, else `mendersoftware/workflows` |
-| `workflows.image.tag` | Docker image tag | `mender-3.1.0` |
+| `workflows.image.tag` | Docker image tag | `mender-3.2.1` |
 | `workflows.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `workflows.replicas` | Number of replicas | `1` |
 | `workflows.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -442,7 +442,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `create_artifact_worker.image.registry` | Docker image registry | `docker.io` |
 | `create_artifact_worker.image.repository` | Docker image repository | `mendersoftware/create-artifact-worker` |
-| `create_artifact_worker.image.tag` | Docker image tag | `mender-3.1.0` |
+| `create_artifact_worker.image.tag` | Docker image tag | `mender-3.2.1` |
 | `create_artifact_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `create_artifact_worker.replicas` | Number of replicas | `1` |
 | `create_artifact_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -461,7 +461,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `auditlogs.image.registry` | Docker image registry | `registry.mender.io` |
 | `auditlogs.image.repository` | Docker image repository | `mendersoftware/auditlogs` |
-| `auditlogs.image.tag` | Docker image tag | `mender-3.1.0` |
+| `auditlogs.image.tag` | Docker image tag | `mender-3.2.1` |
 | `auditlogs.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `auditlogs.replicas` | Number of replicas | `1` |
 | `auditlogs.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -488,7 +488,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `iot_manager.image.registry` | Docker image registry | `docker.io` |
 | `iot_manager.image.repository` | Docker image repository | `mendersoftware/iot-manager` |
-| `iot_manager.image.tag` | Docker image tag | `mender-3.1.0` |
+| `iot_manager.image.tag` | Docker image tag | `mender-3.2.1` |
 | `iot_manager.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `iot_manager.replicas` | Number of replicas | `1` |
 | `iot_manager.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -514,7 +514,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deviceconnect.image.registry` | Docker image registry | `docker.io` |
 | `deviceconnect.image.repository` | Docker image repository | `mendersoftware/deviceconnect` |
-| `deviceconnect.image.tag` | Docker image tag | `mender-3.1.0` |
+| `deviceconnect.image.tag` | Docker image tag | `mender-3.2.1` |
 | `deviceconnect.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deviceconnect.replicas` | Number of replicas | `1` |
 | `deviceconnect.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -540,7 +540,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deviceconfig.image.registry` | Docker image registry | `docker.io` |
 | `deviceconfig.image.repository` | Docker image repository | `mendersoftware/deviceconfig` |
-| `deviceconfig.image.tag` | Docker image tag | `mender-3.1.0` |
+| `deviceconfig.image.tag` | Docker image tag | `mender-3.2.1` |
 | `deviceconfig.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deviceconfig.replicas` | Number of replicas | `1` |
 | `deviceconfig.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
@@ -566,7 +566,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `devicemonitor.image.registry` | Docker image registry | `registry.mender.io` |
 | `devicemonitor.image.repository` | Docker image repository | `mendersoftware/devicemonitor` |
-| `devicemonitor.image.tag` | Docker image tag | `mender-3.1.0` |
+| `devicemonitor.image.tag` | Docker image tag | `mender-3.2.1` |
 | `devicemonitor.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `devicemonitor.replicas` | Number of replicas | `1` |
 | `devicemonitor.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.env.DEVICEAUTH_JWT_ISSUER` | Set the DEVICEAUTH_JWT_ISSUER variable | `Mender` |
 | `device_auth.env.DEVICEAUTH_JWT_EXP_TIMEOUT` | Set the DEVICEAUTH_JWT_EXP_TIMEOUT variable | `604800` |
 | `device_auth.env.DEVICEAUTH_MIDDLEWARE` | Set the DEVICEAUTH_MIDDLEWARE variable | `prod` |
+| `device_auth.env.DEVICEAUTH_REDIS_ADDR` | Set the DEVICEAUTH_REDIS_ADDR variable | `mender-redis:6379` |
+| `device_auth.env.DEVICEAUTH_REDIS_USERNAME` | Set the DEVICEAUTH_REDIS_USERNAME variable | `""` |
+| `device_auth.env.DEVICEAUTH_REDIS_PASSWORD` | Set the DEVICEAUTH_REDIS_PASSWORD variable | `""` |
+| `device_auth.env.DEVICEAUTH_REDIS_DB` | Set the DEVICEAUTH_REDIS_DB variable | `1` |
+| `device_auth.env.DEVICEAUTH_REDIS_TIMEOUT_SEC` | Set the DEVICEAUTH_REDIS_TIMEOUT_SEC variable | `1` |
+| `device_auth.env.DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC` | Set the DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `device_auth.env.DEVICEAUTH_TENANTADM_ADDR` | Set the DEVICEAUTH_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
 
 ### Parameters: gui
@@ -347,6 +353,17 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.env.TENANTADM_SERVER_PRIV_KEY_PATH` | Set the TENANTADM_SERVER_PRIV_KEY_PATH variable | `/etc/tenantadm/rsa/private.pem` |
 | `tenantadm.env.TENANTADM_ORCHESTRATOR_ADDR` | Set the TENANTADM_ORCHESTRATOR_ADDR variable | `http://mender-workflows-server:8080/` |
 | `tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY` | Set the TENANTADM_RECAPTCHA_URL_VERIFY variable | `https://www.google.com/recaptcha/api/siteverify` |
+| `tenantadm.env.TENANTADM_DEFAULT_API_LIMITS` | Set the TENANTADM_DEFAULT_API_LIMITS variable, defining the default rate limits | see below for the default values |
+
+The default value for the rate limits are:
+
+* Management APIs rate limits, per user:
+  * 600 API calls/minute/user
+* Device APIs rate limits, per device:
+  * 60 API calls/minute
+  * 1 API call/5 seconds for each API end-point
+
+You can customize the default API limits setting a custom JSON document. See the [default one here](./mender/templates/tenantadm-deploy.yaml#L82).
 
 ### Parameters: useradm
 
@@ -376,6 +393,12 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.env.USERADM_JWT_ISSUER` | Set the USERADM_JWT_ISSUER variable | `Mender Users` |
 | `useradm.env.USERADM_JWT_EXP_TIMEOUT` | Set the USERADM_JWT_EXP_TIMEOUT variable | `604800` |
 | `useradm.env.USERADM_MIDDLEWARE` | Set the USERADM_MIDDLEWARE variable | `prod` |
+| `useradm.env.USERADM_REDIS_ADDR` | Set the USERADM_REDIS_ADDR variable | `mender-redis:6379` |
+| `useradm.env.USERADM_REDIS_USERNAME` | Set the USERADM_REDIS_USERNAME variable | `""` |
+| `useradm.env.USERADM_REDIS_PASSWORD` | Set the USERADM_REDIS_PASSWORD variable | `""` |
+| `useradm.env.USERADM_REDIS_DB` | Set the USERADM_REDIS_DB variable | `2` |
+| `useradm.env.USERADM_REDIS_TIMEOUT_SEC` | Set the USERADM_REDIS_TIMEOUT_SEC variable | `1` |
+| `useradm.env.USERADM_REDIS_LIMITS_EXPIRE_SEC` | Set the USERADM_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `useradm.env.USERADM_TENANTADM_ADDR` | Set the USERADM_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
 | `useradm.env.USERADM_TOTP_ISSUER` | Set the USERADM_TOTP_ISSUER variable | `Mender` |
 
@@ -556,6 +579,31 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.service.nodePort` | Node port for the service | `nil` |
 | `devicemonitor.env.DEVICEMONITOR_USERADM_URL` | Set the DEVICEMONITOR_USERADM_URL variable | `http://mender-useradm:8080/` |
 | `devicemonitor.env.DEVICEMONITOR_WORKFLOWS_URL` | Set the DEVICEMONITOR_WORKFLOWS_URL variable | `http://mender-workflows-server:8080` |
+
+### Parameters: redis
+
+The following table lists the parameters for the `redis` component and their default values:
+
+| Parameter | Description | Default |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `redis.enabled` | Enable the component | `true` |
+| `redis.image.registry` | Docker image registry | `docker.io` |
+| `redis.image.repository` | Docker image repository | `redis` |
+| `redis.image.tag` | Docker image tag | `6.0.16-alpine` |
+| `redis.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `redis.replicas` | Number of replicas | `1` |
+| `redis.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
+| `redis.resources.limits.cpu` | Resources CPU limit | `50m` |
+| `redis.resources.limits.memory` | Resources memory limit | `64M` |
+| `redis.resources.requests.cpu` | Resources CPU request | `100m` |
+| `redis.resources.requests.memory` | Resources memory request | `128M` |
+| `redis.service.name` | Name of the service | `mender-redis` |
+| `redis.service.annotations` | Annotations map for the service | `{}` |
+| `redis.service.type` | Service type | `ClusterIP` |
+| `redis.service.loadBalancerIP` | Service load balancer IP | `nil` |
+| `redis.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
+| `redis.service.port` | Port for the service | `6379` |
+| `redis.service.nodePort` | Node port for the service | `nil` |
 
 ## Create a tenant and a user from command line
 

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "master"
+appVersion: "3.2.1"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: "3.1.0"
+version: "3.2.1"
 keywords:
 - mender
 - iot

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -15,4 +15,3 @@ maintainers:
 - name: Northern.tech AS
   email: contact@northern.tech
   url: https://northern.tech
-engine: gotpl

--- a/mender/templates/api-gateway-configmap.yaml
+++ b/mender/templates/api-gateway-configmap.yaml
@@ -47,6 +47,7 @@ data:
         auditlogs:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -62,6 +63,7 @@ data:
         iot-manager:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -77,6 +79,7 @@ data:
         deployments:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - sec-headers
           - compression
@@ -91,6 +94,7 @@ data:
         deploymentsDL:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - sec-headers
           - json-error-responder1
           - json-error-responder2
@@ -103,6 +107,7 @@ data:
         deploymentsMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -118,6 +123,7 @@ data:
         deviceauth:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - sec-headers
           - compression
           rule: "PathPrefix(`/api/devices/{ver:v[0-9]+}/authentication`)"
@@ -127,6 +133,7 @@ data:
         deviceauthMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -142,6 +149,7 @@ data:
         deviceconfig:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - sec-headers
           - compression
@@ -156,6 +164,7 @@ data:
         deviceconfigMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -171,6 +180,7 @@ data:
         deviceconnect:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - sec-headers
           - compression
@@ -185,6 +195,7 @@ data:
         deviceconnectMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -202,6 +213,7 @@ data:
         devicemonitor:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - sec-headers
           - compression
@@ -216,6 +228,7 @@ data:
         devicemonitorMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -231,6 +244,7 @@ data:
         gui:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - ensure-ui-path
           - signup-redirect
           - ui-stripprefix
@@ -250,6 +264,7 @@ data:
         inventoryV1:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - inventoryV1-replacepathregex
           - sec-headers
@@ -265,6 +280,7 @@ data:
         inventoryV2:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - devauth
           - sec-headers
           - compression
@@ -279,6 +295,7 @@ data:
         inventoryMgmtV1:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - inventoryMgmtV1-replacepathregex
           - sec-headers
@@ -292,6 +309,7 @@ data:
         inventoryMgmtV2:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -307,6 +325,7 @@ data:
         tenantadm:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -317,6 +336,7 @@ data:
         tenantadmSignup:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - sec-headers
           - compression
           rule: >-
@@ -331,6 +351,7 @@ data:
         useradm:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - userauth
           - sec-headers
           - compression
@@ -343,6 +364,7 @@ data:
         useradmNoAuth:
           entrypoints: {{ $scheme }}
           middlewares:
+          - ratelimit
           - sec-headers
           - compression
           - json-error-responder4
@@ -472,6 +494,10 @@ data:
 
         compression:
           compress: true
+
+        ratelimit:
+          rateLimit:
+{{ toYaml .Values.api_gateway.rateLimit | indent 12 }}
 
         devauth:
           forwardAuth:

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -94,12 +94,26 @@ spec:
           value: {{ .Values.device_auth.env.DEVICEAUTH_JWT_EXP_TIMEOUT | quote }}
         - name: DEVICEAUTH_MIDDLEWARE
           value: {{ .Values.device_auth.env.DEVICEAUTH_MIDDLEWARE | quote }}
-        {{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) }}
+{{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) }}
         - name: DEVICEAUTH_HAVE_ADDONS
           value: "true"
         - name: DEVICEAUTH_TENANTADM_ADDR
           value: {{ .Values.device_auth.env.DEVICEAUTH_TENANTADM_ADDR | quote }}
-        {{- end }}
+{{- end }}
+{{- if .Values.global.enterprise }}
+        - name: DEVICEAUTH_REDIS_ADDR
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_ADDR | quote }}
+        - name: DEVICEAUTH_REDIS_USERNAME
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_USERNAME | quote }}
+        - name: DEVICEAUTH_REDIS_PASSWORD
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_PASSWORD | quote }}
+        - name: DEVICEAUTH_REDIS_DB
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_DB | quote }}
+        - name: DEVICEAUTH_REDIS_TIMEOUT_SEC
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_TIMEOUT_SEC | quote }}
+        - name: DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC
+          value: {{ .Values.useradm.env.DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC | quote }}
+{{- end }}
 
         # Supported configuration settings: https://github.com/mendersoftware/deviceauth/blob/master/config.yaml
         # Set in order, last value for the key will be used in case duplications.

--- a/mender/templates/gui-deploy.yaml
+++ b/mender/templates/gui-deploy.yaml
@@ -62,9 +62,9 @@ spec:
 
         env:
         - name: INTEGRATION_VERSION
-          value: "3.1.0"
+          value: "3.2.1"
         - name: MENDER_VERSION
-          value: "3.1.0"
+          value: "3.2.1"
         - name: MENDER_ARTIFACT_VERSION
           value: "3.6.0"
         {{- if .Values.global.hosted }}

--- a/mender/templates/iot-manager-svc.yaml
+++ b/mender/templates/iot-manager-svc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.iot_manager.enabled .Values.global.enterprise }}
+{{- if .Values.iot_manager.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/mender/templates/redis-deploy.yaml
+++ b/mender/templates/redis-deploy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.redis.enabled .Values.global.enterprise }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: mender
+    helm.sh/chart: "{{ .Chart.Name }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+
+  # if deployment is not completed within 10 min, consider it failed,
+  # as result deployment Reason=ProgressDeadlineExceeded
+  # needs to be big enough to rollout to complete
+  progressDeadlineSeconds: 600
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      {{- with .Values.redis.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: redis
+        image: {{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+        imagePullPolicy: {{ .Values.redis.image.imagePullPolicy }}
+        resources:
+{{ toYaml .Values.redis.resources | indent 10 }}
+
+{{- end }}

--- a/mender/templates/redis-svc.yaml
+++ b/mender/templates/redis-svc.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.redis.enabled .Values.global.enterprise }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redis.service.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: redis-svc
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: mender
+    helm.sh/chart: "{{ .Chart.Name }}"
+{{- with .Values.redis.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.redis.service.type }}
+  {{- if and (eq .Values.redis.service.type "ClusterIP") .Values.redis.service.clusterIP }}
+  clusterIP: {{ .Values.redis.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.redis.service.type "LoadBalancer") .Values.redis.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.redis.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.redis.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.redis.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.redis.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.redis.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.redis.service.port }}
+    protocol: TCP
+    targetPort: 6379
+    {{- if .Values.redis.service.nodePort }}
+    nodePort: {{ .Values.redis.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: redis
+{{- end }}

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -78,6 +78,8 @@ spec:
           value: {{ .Values.tenantadm.env.TENANTADM_ORCHESTRATOR_ADDR | quote }}
         - name: TENANTADM_RECAPTCHA_URL_VERIFY
           value: {{ .Values.tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY | quote }}
+        - name: TENANTADM_DEFAULT_API_LIMITS
+          value: {{ .Values.tenantadm.env.TENANTADM_DEFAULT_API_LIMITS | quote }}
 
         # Supported configuration settings: https://github.com/mendersoftware/tenantadm/blob/master/config.yaml
         # Set in order, last value for the key will be used in case duplications.

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -80,6 +80,10 @@ spec:
           value: {{ .Values.tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY | quote }}
         - name: TENANTADM_DEFAULT_API_LIMITS
           value: {{ .Values.tenantadm.env.TENANTADM_DEFAULT_API_LIMITS | quote }}
+{{- if .Values.global.hosted }}
+        - name: TENANTADM_ENABLE_SELF_SERVICE_SIGN_UP
+          value: {{ .Values.global.hosted | quote }}
+{{- end }}
 
         # Supported configuration settings: https://github.com/mendersoftware/tenantadm/blob/master/config.yaml
         # Set in order, last value for the key will be used in case duplications.

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -64,8 +64,6 @@ spec:
           value: {{ .Values.useradm.env.USERADM_JWT_ISSUER | quote }}
         - name: USERADM_JWT_EXP_TIMEOUT
           value: {{ .Values.useradm.env.USERADM_JWT_EXP_TIMEOUT | quote }}
-        - name: USERADM_MIDDLEWARE
-          value: {{ .Values.useradm.env.USERADM_MIDDLEWARE | quote }}
         {{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) }}
         - name: USERADM_HAVE_ADDONS
           value: "true"

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -76,6 +76,20 @@ spec:
         - name: DEPLOYMENTS_ENABLE_AUDIT
           value: "true"
 {{- end }}
+{{- if .Values.global.enterprise }}
+        - name: USERADM_REDIS_ADDR
+          value: {{ .Values.useradm.env.USERADM_REDIS_ADDR | quote }}
+        - name: USERADM_REDIS_USERNAME
+          value: {{ .Values.useradm.env.USERADM_REDIS_USERNAME | quote }}
+        - name: USERADM_REDIS_PASSWORD
+          value: {{ .Values.useradm.env.USERADM_REDIS_PASSWORD | quote }}
+        - name: USERADM_REDIS_DB
+          value: {{ .Values.useradm.env.USERADM_REDIS_DB | quote }}
+        - name: USERADM_REDIS_TIMEOUT_SEC
+          value: {{ .Values.useradm.env.USERADM_REDIS_TIMEOUT_SEC | quote }}
+        - name: USERADM_REDIS_LIMITS_EXPIRE_SEC
+          value: {{ .Values.useradm.env.USERADM_REDIS_LIMITS_EXPIRE_SEC | quote }}
+{{- end }}
 
         # Readiness/liveness probes
         readinessProbe:

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -110,6 +110,12 @@ device_auth:
     DEVICEAUTH_JWT_ISSUER: Mender
     DEVICEAUTH_JWT_EXP_TIMEOUT: 604800
     DEVICEAUTH_MIDDLEWARE: prod
+    DEVICEAUTH_REDIS_ADDR: "mender-redis:6379"
+    DEVICEAUTH_REDIS_USERNAME: ""
+    DEVICEAUTH_REDIS_PASSWORD: ""
+    DEVICEAUTH_REDIS_DB: "1"
+    DEVICEAUTH_REDIS_TIMEOUT_SEC: "1"
+    DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC: "3600"
     DEVICEAUTH_TENANTADM_ADDR: http://mender-tenantadm:8080
 
 gui:
@@ -181,6 +187,7 @@ tenantadm:
     type: ClusterIP
     port: 8080
   env:
+    TENANTADM_DEFAULT_API_LIMITS: '{"management":{"bursts":[],"quota":{"max_calls":600,"interval_sec":60}},"devices":{"bursts":[{"action":"POST","uri":"/api/devices/v1/authentication","min_interval_sec":5},{"action":"GET","uri":"/api/devices/v1/deployments/device/deployments/next","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/deployments/device/deployments/next","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v2/deployments/device/deployments/next","min_interval_sec":5},{"action":"GET","uri":"/api/devices/v1/deviceconfig/configuration","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/deviceconfig/configuration","min_interval_sec":5},{"action":"PATCH","uri":"/api/devices/v1/inventory/device/attributes","min_interval_sec":5},{"action":"PUT","uri":"/api/devices/v1/inventory/device/attributes","min_interval_sec":5}],"quota":{"max_calls":60,"interval_sec":60}}}'
     TENANTADM_MIDDLEWARE: prod
     TENANTADM_SERVER_PRIV_KEY_PATH: /etc/tenantadm/rsa/private.pem
     TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
@@ -212,6 +219,12 @@ useradm:
     USERADM_JWT_ISSUER: Mender Users
     USERADM_JWT_EXP_TIMEOUT: 604800
     USERADM_MIDDLEWARE: prod
+    USERADM_REDIS_ADDR: "mender-redis:6379"
+    USERADM_REDIS_USERNAME: ""
+    USERADM_REDIS_PASSWORD: ""
+    USERADM_REDIS_DB: "1"
+    USERADM_REDIS_TIMEOUT_SEC: "1"
+    USERADM_REDIS_LIMITS_EXPIRE_SEC: "3600"
     USERADM_TENANTADM_ADDR: http://mender-tenantadm:8080
     USERADM_TOTP_ISSUER: Mender
 
@@ -370,3 +383,25 @@ devicemonitor:
     annotations: {}
     type: ClusterIP
     port: 8080
+
+redis:
+  enabled: true
+  replicas: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128M
+    requests:
+      cpu: 50m
+      memory: 64M
+  affinity: {}
+  image:
+    registry: docker.io
+    repository: redis
+    tag: 6.0.16-alpine
+    imagePullPolicy: IfNotPresent
+  service:
+    name: mender-redis
+    annotations: {}
+    type: ClusterIP
+    port: 6379

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -55,6 +55,13 @@ api_gateway:
   minio:
     enabled: true
     url: "http://minio:9000"
+  rateLimit:
+    average: 100
+    burst: 100
+    period: "1s"
+    sourceCriterion:
+      ipStrategy:
+        depth: 1
 
 deployments:
   enabled: true


### PR DESCRIPTION
Add a redis pod and configure deviceauth and useradm to connect to it
enabling rate limits and caching of JWT tokens. At the same time, set
default rate limits in tenantadm.

Ticket: MEN-5270

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>