### PR TITLE
feat: allow to use external secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following table lists the global parameters supported by the chart and their
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `global.mongodb.existingSecret` | MongoDB existing secret | `null` |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |
+| `global.nats.existingSecret` | NATS existing secret | `null` |
 | `global.nats.URL` | NATS URL | `nats://nats:4222` |
 | `global.s3.AWS_URI` | AWS S3 / MinIO URI | value from `global.url` |
 | `global.s3.AWS_EXTERNAL_URI` | External AWS S3 / MinIO URI | `null` |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The following table lists the global parameters supported by the chart and their
 | `global.image.username` | Global Docker image registry username | `nil` |
 | `global.image.password` | Global Docker image registry username | `password` |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
+| `global.mongodb.existingSecret` | MongoDB existing secret | `null` |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |
 | `global.nats.URL` | NATS URL | `nats://nats:4222` |
 | `global.s3.AWS_URI` | AWS S3 / MinIO URI | value from `global.url` |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The following table lists the global parameters supported by the chart and their
 | `global.hosted` | Enabled Hosted Mender specific features | `false` |
 | `global.image.registry` | Global Docker image registry | `registry.mender.io` |
 | `global.image.username` | Global Docker image registry username | `nil` |
-| `global.image.password` | Global Docker image registry username | `password` |
+| `global.image.password` | Global Docker image registry password | `password` |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `global.mongodb.existingSecret` | MongoDB existing secret | `null` |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |

--- a/mender/templates/auditlogs-deploy.yaml
+++ b/mender/templates/auditlogs-deploy.yaml
@@ -80,7 +80,7 @@ spec:
         envFrom:
         - prefix: AUDITLOGS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -72,7 +72,7 @@ spec:
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -104,7 +104,7 @@ spec:
             name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
         - prefix: DEPLOYMENTS_
           secretRef:
-            name: s3-artifacts
+            name: {{ .Values.global.s3.existingSecret | default "s3-artifacts" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -101,7 +101,7 @@ spec:
         envFrom:
         - prefix: DEPLOYMENTS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
         - prefix: DEPLOYMENTS_
           secretRef:
             name: s3-artifacts

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -124,7 +124,7 @@ spec:
         envFrom:
         - prefix: DEVICEAUTH_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- with .Values.device_auth.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -90,7 +90,7 @@ spec:
         envFrom:
         - prefix: DEVICECONFIG_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -76,9 +76,10 @@ spec:
 
         env:
         # NATS uri
+{{- if not .Values.global.nats.existingSecret }}
         - name: DEVICECONNECT_NATS_URI
           value: "{{ .Values.global.nats.URL }}"
-
+{{- end }}
         # Enable audit logging
 {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEVICECONNECT_ENABLE_AUDIT
@@ -101,6 +102,11 @@ spec:
         - prefix: DEVICECONNECT_
           secretRef:
             name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
+{{- if .Values.global.nats.existingSecret }}
+        - prefix: DEVICECONNECT_
+          secretRef:
+            name: {{ .Values.global.nats.existingSecret }}
+{{- end -}}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -100,7 +100,7 @@ spec:
         envFrom:
         - prefix: DEVICECONNECT_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/devicemonitor-deploy.yaml
+++ b/mender/templates/devicemonitor-deploy.yaml
@@ -88,7 +88,7 @@ spec:
         envFrom:
         - prefix: DEVICEMONITOR_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/inventory-deploy.yaml
+++ b/mender/templates/inventory-deploy.yaml
@@ -87,7 +87,7 @@ spec:
         envFrom:
         - prefix: INVENTORY_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/iot-manager-deploy.yaml
+++ b/mender/templates/iot-manager-deploy.yaml
@@ -80,7 +80,7 @@ spec:
         envFrom:
         - prefix: IOT_MANAGER_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/secret-mongodb-common.yaml
+++ b/mender/templates/secret-mongodb-common.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.mongodb.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,5 @@ type: Opaque
 data:
   MONGO: {{ .Values.global.mongodb.URL | b64enc }}
   MONGO_URL: {{ .Values.global.mongodb.URL | b64enc }}
+{{- end }}
+

--- a/mender/templates/secret-s3-artifacts.yaml
+++ b/mender/templates/secret-s3-artifacts.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.s3.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -94,7 +94,7 @@ spec:
         envFrom:
         - prefix: TENANTADM_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- with .Values.tenantadm.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -122,7 +122,7 @@ spec:
 
         envFrom:
         - secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
           prefix: USERADM_
 
 {{- with .Values.useradm.nodeSelector }}

--- a/mender/templates/workflows-server-deploy.yaml
+++ b/mender/templates/workflows-server-deploy.yaml
@@ -87,7 +87,7 @@ spec:
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -83,7 +83,7 @@ spec:
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
         - prefix: WORKFLOWS_
           secretRef:
             name: smtp

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -7,6 +7,7 @@ global:
     username: null
     password: null
   mongodb:
+    existingSecret: ""
     URL: mongodb://mongodb
   nats:
     URL: nats://nats:4222

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -10,6 +10,7 @@ global:
     existingSecret: ""
     URL: mongodb://mongodb
   nats:
+    existingSecret: ""
     URL: nats://nats:4222
   s3:
     AWS_URI: ""

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -13,6 +13,7 @@ global:
     existingSecret: ""
     URL: nats://nats:4222
   s3:
+    existingSecret: ""
     AWS_URI: ""
     AWS_EXTERNAL_URI: ""
     AWS_BUCKET: mender-artifact-storage


### PR DESCRIPTION
This merge request allows to use secrets for mender deployment.

This makes it easier to deploy Mender with the Postgresql database, Nats and Minio. It is then easier to deploy mender without having to manage passwords.