### PR TITLE
feat: add support for the AWS_EXTERNAL_URI deployments' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ The following table lists the global parameters supported by the chart and their
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |
 | `global.nats.URL` | NATS URL | `nats://nats:4222` |
-| `global.s3.AWS_URI` | AWS S3 / MinIO URI | `http://minio:9000` |
+| `global.s3.AWS_URI` | AWS S3 / MinIO URI | value from `global.url` |
+| `global.s3.AWS_EXTERNAL_URI` | External AWS S3 / MinIO URI | `null` |
 | `global.s3.AWS_BUCKET` | AWS S3 / MinIO bucket | `minio-hosted-mender-artifacts` |
 | `global.s3.AWS_REGION` | AWS S3 region | `us-east-1` |
 | `global.s3.AWS_ACCESS_KEY_ID` | AWS S3 / MinIO key ID | `myaccesskey` |

--- a/mender/templates/secret-s3-artifacts.yaml
+++ b/mender/templates/secret-s3-artifacts.yaml
@@ -12,6 +12,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 data:
   AWS_URI: {{ .Values.global.s3.AWS_URI | default .Values.global.url | default (ternary (printf "https://%s" .Values.api_gateway.service.name ) (printf "http://%s" .Values.api_gateway.service.name) (.Values.api_gateway.env.SSL)) | b64enc }}
+{{- if .Values.global.s3.AWS_EXTERNAL_URI }}
+  AWS_EXTERNAL_URI: {{ .Values.global.s3.AWS_EXTERNAL_URI }}
+{{- end }}
   AWS_BUCKET: {{ .Values.global.s3.AWS_BUCKET | b64enc }}
   AWS_REGION: {{ .Values.global.s3.AWS_REGION | b64enc }}
 {{- if not .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -12,6 +12,7 @@ global:
     URL: nats://nats:4222
   s3:
     AWS_URI: ""
+    AWS_EXTERNAL_URI: ""
     AWS_BUCKET: mender-artifact-storage
     AWS_REGION: us-east-1
     AWS_ACCESS_KEY_ID: myaccesskey


### PR DESCRIPTION
Setting a value for the AWS_EXTERNAL_URI env variable in the deployments
service, it is possible to use an external URL for the S3 storage when
generating presigned download URLs and an internal URL for all the other
API calls (e.g., uploading of artifacts). If AWS_EXTERNAL_URI is not
set, it defaults to AWS_URI (internal URL), making this change
back-compatible.

Changelog: Title
Ticket: MEN-5280

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>

Requires: https://github.com/mendersoftware/deployments/pull/728