### PR TITLE
feat: Configurable container ports for api-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.podAnnotations` | add custom pod annotations | `nil` |
 | `api_gateway.replicas` | Number of replicas | `1` |
 | `api_gateway.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
+| `api_gateway.httpPort` | Port for the HTTP listener in the container | `80` |
+| `api_gateway.httpsPort` | Port for the HTTPS listener in the container | `443` |
 | `api_gateway.resources.limits.cpu` | Resources CPU limit | `600m` |
 | `api_gateway.resources.limits.memory` | Resources memory limit | `1G` |
 | `api_gateway.resources.requests.cpu` | Resources CPU request | `600m` |

--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -55,8 +55,8 @@ spec:
             - --api.dashboard=true
             - --api.insecure=true
 {{- end }}
-            - --entrypoints.http.address=:{{- .Values.api_gateway.service.httpPort }}
-            - --entrypoints.https.address=:{{- .Values.api_gateway.service.httpsPort }}
+            - --entrypoints.http.address=:{{- .Values.api_gateway.httpPort }}
+            - --entrypoints.https.address=:{{- .Values.api_gateway.httpsPort }}
             - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
@@ -73,9 +73,9 @@ spec:
 
         ports:
 {{- if .Values.api_gateway.env.SSL }}
-        - containerPort: 443
+        - containerPort: {{ .Values.api_gateway.httpsPort }}
 {{- end }}
-        - containerPort: 80
+        - containerPort: {{ .Values.api_gateway.httpPort }}
 
         # Readiness/liveness/startup probes
         livenessProbe:
@@ -83,7 +83,7 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 80
+            port: {{ .Values.api_gateway.httpPort }}
           initialDelaySeconds: 5
           periodSeconds: 5
         readinessProbe:
@@ -91,14 +91,14 @@ spec:
           failureThreshold: 1
           httpGet:
             path: /healthz
-            port: 80
+            port: {{ .Values.api_gateway.httpPort }}
           periodSeconds: 15
           initialDelaySeconds: 5
         startupProbe:
           failureThreshold: 30
           httpGet:
             path: /healthz
-            port: 80
+            port: {{ .Values.api_gateway.httpPort }}
           initialDelaySeconds: 5
           periodSeconds: 5
 

--- a/mender/templates/api-gateway-svc.yaml
+++ b/mender/templates/api-gateway-svc.yaml
@@ -32,7 +32,7 @@ spec:
 {{- if .Values.api_gateway.env.SSL }}
   - port: {{ .Values.api_gateway.service.httpsPort }}
     protocol: TCP
-    targetPort: {{ .Values.api_gateway.service.httpsPort }}
+    targetPort: {{ .Values.api_gateway.httpsPort }}
     {{- if .Values.api_gateway.httpsNodePort }}
     nodePort: {{ .Values.api_gateway.service.httpsNodePort }}
     {{- end }}
@@ -40,7 +40,7 @@ spec:
 {{- end }}
   - port: {{ .Values.api_gateway.service.httpPort }}
     protocol: TCP
-    targetPort: {{ .Values.api_gateway.service.httpPort }}
+    targetPort: {{ .Values.api_gateway.httpPort }}
     {{- if .Values.api_gateway.service.httpNodePort }}
     nodePort: {{ .Values.api_gateway.service.httpNodePort }}
     {{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -47,6 +47,8 @@ api_gateway:
       memory: 512M
   affinity: {}
   nodeSelector: {}
+  httpPort: 80
+  httpsPort: 443
   service:
     name: mender-api-gateway
     annotations: {}


### PR DESCRIPTION
The commit "feat: Reuse service port for api-gateway entrypoints" in #90 made the `api_gateway` deployment configurable using the service ports. However, I ran into some problems using this:
1. In a Red Hat OpenShift cluster, the container ports cannot be privileged (<1024) ports, so it is common to have the service on privileged ports (80/443) and the container listening on non-privileged ports (8888/8443).
2. The two containerPort settings and readiness/liveness/startup probes are not configurable but need to use the same ports.

I added new settings `api_gateway.httpPort` and `api_gateway.httpsPort` that are used to configure all the ports in the deployment, and also the target ports in the service.