### PR TITLE
Add max image size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.service.nodePort` | Node port for the service | `nil` |
 | `deployments.env.DEPLOYMENTS_MIDDLEWARE` | Set the DEPLOYMENTS_MIDDLEWARE variable | `prod` |
 | `deployments.env.DEPLOYMENTS_PRESIGN_SECRET` | Set the secret for generating signed url, must be a base64 encoded secret. | random value at start-up time |
+| `deployments.env.DEPLOYMENTS_AWS_MAX_IMAGE_SIZE` | Set the max artifact image size in bytes. | `nil`, code defaults to 10GB |
 
 ### Parameters: device-auth
 

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -87,6 +87,8 @@ spec:
           value: {{ .Values.deployments.env.DEPLOYMENTS_AWS_TAG_ARTIFACT | quote }}
         - name: DEPLOYMENTS_PRESIGN_SECRET
           value: {{ .Values.deployments.env.DEPLOYMENTS_PRESIGN_SECRET | quote }}
+        - name: DEPLOYMENTS_AWS_MAX_IMAGE_SIZE
+          value: {{ .Values.deployments.env.DEPLOYMENTS_AWS_MAX_IMAGE_SIZE | quote }}
 {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: DEPLOYMENTS_ENABLE_AUDIT
           value: "true"


### PR DESCRIPTION
Adding AWS_MAX_IMAGE_SIZE parameter to limit size of uploads. Defaults to 10GB.