### PR TITLE
Add podSecurityContext and containerSecurityContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.podAnnotations` | add custom pod annotations | `nil` |
 | `api_gateway.replicas` | Number of replicas | `1` |
 | `api_gateway.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
-| `api_gateway.httpPort` | Port for the HTTP listener in the container | `80` |
-| `api_gateway.httpsPort` | Port for the HTTPS listener in the container | `443` |
+| `api_gateway.httpPort` | Port for the HTTP listener in the container | `9080` |
+| `api_gateway.httpsPort` | Port for the HTTPS listener in the container | `9443` |
 | `api_gateway.resources.limits.cpu` | Resources CPU limit | `600m` |
 | `api_gateway.resources.limits.memory` | Resources memory limit | `1G` |
 | `api_gateway.resources.requests.cpu` | Resources CPU request | `600m` |
@@ -239,7 +239,12 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.rateLimit.burst` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `100` |
 | `api_gateway.rateLimit.period` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `1s` |
 | `api_gateway.rateLimit.sourceCriterion` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `{"ipStrategy": {"depth": 1}}` |
-
+| `api_gateway.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `api_gateway.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `api_gateway.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `api_gateway.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `api_gateway.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `api_gateway.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: deployments
 
@@ -270,6 +275,12 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.service.nodePort` | Node port for the service | `nil` |
 | `deployments.env.DEPLOYMENTS_MIDDLEWARE` | Set the DEPLOYMENTS_MIDDLEWARE variable | `prod` |
 | `deployments.env.DEPLOYMENTS_PRESIGN_SECRET` | Set the secret for generating signed url, must be a base64 encoded secret. | random value at start-up time |
+| `deployments.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deployments.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `deployments.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `deployments.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deployments.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `deployments.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: device-auth
 
@@ -310,6 +321,12 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.env.DEVICEAUTH_REDIS_TIMEOUT_SEC` | Set the DEVICEAUTH_REDIS_TIMEOUT_SEC variable | `1` |
 | `device_auth.env.DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC` | Set the DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `device_auth.env.DEVICEAUTH_TENANTADM_ADDR` | Set the DEVICEAUTH_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
+| `device_auth.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `device_auth.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `device_auth.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `device_auth.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `device_auth.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `device_auth.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: gui
 
@@ -337,6 +354,13 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `gui.service.port` | Port for the service | `80` |
 | `gui.service.nodePort` | Node port for the service | `nil` |
+| `gui.httpPort` | Port for the HTTP listener in the container | `80` |
+| `gui.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `gui.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `gui.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `gui.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `gui.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `gui.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: inventory
 
@@ -366,6 +390,12 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.service.port` | Port for the service | `8080` |
 | `inventory.service.nodePort` | Node port for the service | `nil` |
 | `inventory.env.INVENTORY_MIDDLEWARE` | Set the INVENTORY_MIDDLEWARE variable | `prod` |
+| `inventory.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `inventory.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `inventory.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `inventory.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `inventory.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `inventory.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: reporting
 
@@ -426,6 +456,12 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.env.TENANTADM_ORCHESTRATOR_ADDR` | Set the TENANTADM_ORCHESTRATOR_ADDR variable | `http://mender-workflows-server:8080/` |
 | `tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY` | Set the TENANTADM_RECAPTCHA_URL_VERIFY variable | `https://www.google.com/recaptcha/api/siteverify` |
 | `tenantadm.env.TENANTADM_DEFAULT_API_LIMITS` | Set the TENANTADM_DEFAULT_API_LIMITS variable, defining the default rate limits | see below for the default values |
+| `tenantadm.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `tenantadm.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `tenantadm.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `tenantadm.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `tenantadm.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `tenantadm.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 The default value for the rate limits are:
 
@@ -476,6 +512,12 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.env.USERADM_REDIS_LIMITS_EXPIRE_SEC` | Set the USERADM_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `useradm.env.USERADM_TENANTADM_ADDR` | Set the USERADM_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
 | `useradm.env.USERADM_TOTP_ISSUER` | Set the USERADM_TOTP_ISSUER variable | `Mender` |
+| `useradm.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `useradm.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `useradm.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `useradm.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `useradm.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `useradm.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: workflows
 
@@ -504,6 +546,12 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `workflows.service.port` | Port for the service | `8080` |
 | `workflows.service.nodePort` | Node port for the service | `nil` |
+| `workflows.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `workflows.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `workflows.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `workflows.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `workflows.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `workflows.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: create_artifact_worker
 
@@ -525,6 +573,12 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.resources.limits.memory` | Resources memory limit | `1024M` |
 | `create_artifact_worker.resources.requests.cpu` | Resources CPU request | `100m` |
 | `create_artifact_worker.resources.requests.memory` | Resources memory request | `128M` |
+| `create_artifact_worker.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `create_artifact_worker.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `create_artifact_worker.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `create_artifact_worker.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `create_artifact_worker.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `create_artifact_worker.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: auditlogs
 
@@ -553,6 +607,12 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `auditlogs.service.port` | Port for the service | `8080` |
 | `auditlogs.service.nodePort` | Node port for the service | `nil` |
+| `auditlogs.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `auditlogs.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `auditlogs.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `auditlogs.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `auditlogs.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `auditlogs.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: iot-manager
 
@@ -581,6 +641,12 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `iot_manager.service.port` | Port for the service | `8080` |
 | `iot_manager.service.nodePort` | Node port for the service | `nil` |
+| `iot_manager.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `iot_manager.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `iot_manager.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `iot_manager.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `iot_manager.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `iot_manager.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: deviceconnect
 
@@ -609,6 +675,12 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `deviceconnect.service.port` | Port for the service | `8080` |
 | `deviceconnect.service.nodePort` | Node port for the service | `nil` |
+| `deviceconnect.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deviceconnect.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `deviceconnect.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `deviceconnect.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deviceconnect.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `deviceconnect.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: deviceconfig
 
@@ -637,6 +709,12 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `deviceconfig.service.port` | Port for the service | `8080` |
 | `deviceconfig.service.nodePort` | Node port for the service | `nil` |
+| `deviceconfig.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deviceconfig.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `deviceconfig.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `deviceconfig.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `deviceconfig.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `deviceconfig.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: devicemonitor
 
@@ -667,6 +745,12 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.service.nodePort` | Node port for the service | `nil` |
 | `devicemonitor.env.DEVICEMONITOR_USERADM_URL` | Set the DEVICEMONITOR_USERADM_URL variable | `http://mender-useradm:8080/` |
 | `devicemonitor.env.DEVICEMONITOR_WORKFLOWS_URL` | Set the DEVICEMONITOR_WORKFLOWS_URL variable | `http://mender-workflows-server:8080` |
+| `devicemonitor.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `devicemonitor.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `devicemonitor.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
+| `devicemonitor.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `devicemonitor.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `devicemonitor.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
 
 ### Parameters: generate_delta_worker
 
@@ -713,6 +797,12 @@ The following table lists the parameters for the `redis` component and their def
 | `redis.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `redis.service.port` | Port for the service | `6379` |
 | `redis.service.nodePort` | Node port for the service | `nil` |
+| `redis.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `redis.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `redis.podSecurityContext.runAsUser` | User ID for the pod | `999` |
+| `redis.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
+| `redis.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
+| `redis.containerSecurityContext.runAsUser` | User ID for the container | `999` |
 
 ## Create a tenant and a user from command line
 

--- a/mender/templates/api-gateway-deploy.yaml
+++ b/mender/templates/api-gateway-deploy.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.api_gateway.enabled }}
+{{- if or .Values.api_gateway.podSecurityContext.enabled .Values.api_gateway.containerSecurityContext.enabled }}
+  {{- if lt (int .Values.api_gateway.httpPort) 1024  }}
+    {{- fail ".Values.api_gateway.httpPort can't be less than 1024 when Security Context is enabled" }}
+  {{- end }}
+  {{- if lt (int .Values.api_gateway.httpsPort) 1024  }}
+    {{- fail ".Values.api_gateway.httpsPort can't be less than 1024 when Security Context is enabled" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,11 +50,17 @@ spec:
       {{- with .Values.api_gateway.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.api_gateway.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.api_gateway.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: api-gateway
         image: {{ .Values.api_gateway.image.registry }}/{{ .Values.api_gateway.image.repository }}:{{ .Values.api_gateway.image.tag }}
         imagePullPolicy: {{ .Values.api_gateway.image.imagePullPolicy }}
+{{- if .Values.api_gateway.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.api_gateway.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         args:
             - --accesslog=true
             - --accesslog.format=json

--- a/mender/templates/auditlogs-deploy.yaml
+++ b/mender/templates/auditlogs-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.auditlogs.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.auditlogs.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.auditlogs.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: auditlogs
         image: {{ .Values.auditlogs.image.registry }}/{{ .Values.auditlogs.image.repository }}:{{ .Values.auditlogs.image.tag }}
         imagePullPolicy: {{ .Values.auditlogs.image.imagePullPolicy }}
+{{- if .Values.auditlogs.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.auditlogs.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.auditlogs.resources | indent 10 }}
 

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.create_artifact_worker.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.create_artifact_worker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.create_artifact_worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: workflows
         image: {{ .Values.create_artifact_worker.image.registry }}/{{ .Values.create_artifact_worker.image.repository }}:{{ .Values.create_artifact_worker.image.tag }}
         imagePullPolicy: {{ .Values.create_artifact_worker.image.imagePullPolicy }}
+{{- if .Values.create_artifact_worker.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.create_artifact_worker.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.create_artifact_worker.resources | indent 10 }}
 

--- a/mender/templates/db-migration-job.yaml
+++ b/mender/templates/db-migration-job.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/part-of: mender
     helm.sh/chart: "{{ .Chart.Name }}"
 spec:
-  backoffLimit: {{ .Values.dbmigration.backoffLimit | default 5 }} 
+  backoffLimit: {{ .Values.dbmigration.backoffLimit | default 5 }}
   template:
     metadata:
       labels:
@@ -28,6 +28,10 @@ spec:
       {{- with .Values.dbmigration.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.dbmigration.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.dbmigration.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
+
 {{- if .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}
       serviceAccountName: {{ .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}
 {{- end }}
@@ -39,6 +43,9 @@ spec:
       - name: tenantadm-migration
         image: {{ .Values.tenantadm.image.registry | default "registry.mender.io" }}/{{ .Values.tenantadm.image.repository | default "mendersoftware/tenantadm-enterprise" }}:{{ .Values.tenantadm.image.tag }}
         imagePullPolicy: {{ .Values.tenantadm.image.imagePullPolicy }}
+{{- if .Values.tenantadm.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.tenantadm.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: TENANTADM_
           secretRef:
@@ -56,6 +63,9 @@ spec:
         image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deployments.image.imagePullPolicy }}
+{{- if .Values.deployments.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deployments.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: DEPLOYMENTS_
           secretRef:
@@ -73,6 +83,9 @@ spec:
         image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.device_auth.image.imagePullPolicy }}
+{{- if .Values.device_auth.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.device_auth.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: DEVICEAUTH_
           secretRef:
@@ -90,6 +103,9 @@ spec:
         image: {{ .Values.deviceconfig.image.registry | default "docker.io" }}/{{ .Values.deviceconfig.image.repository | default "mendersoftware/deviceconfig" }}:{{ .Values.deviceconfig.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deviceconfig.image.imagePullPolicy }}
+{{- if .Values.deviceconfig.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deviceconfig.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: DEVICECONFIG_
           secretRef:
@@ -103,6 +119,9 @@ spec:
       - name: devicemonitor-migration
         image: {{ .Values.devicemonitor.image.registry | default "registry.mender.io" }}/{{ .Values.devicemonitor.image.repository | default "mendersoftware/devicemonitor-enterprise" }}:{{ .Values.devicemonitor.image.tag }}
         imagePullPolicy: {{ .Values.devicemonitor.image.imagePullPolicy }}
+{{- if .Values.devicemonitor.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.devicemonitor.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: DEVICEMONITOR_
           secretRef:
@@ -120,6 +139,9 @@ spec:
         image: {{ .Values.deviceconnect.image.registry | default "docker.io" }}/{{ .Values.deviceconnect.image.repository | default "mendersoftware/deviceconnect" }}:{{ .Values.deviceconnect.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deviceconnect.image.imagePullPolicy }}
+{{- if .Values.deviceconnect.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deviceconnect.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: DEVICECONNECT_
           secretRef:
@@ -136,6 +158,9 @@ spec:
         image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.inventory.image.imagePullPolicy }}
+{{- if .Values.inventory.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.inventory.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: INVENTORY_
           secretRef:
@@ -152,6 +177,9 @@ spec:
         image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
+{{- if .Values.useradm.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.useradm.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         env:
         - name: USERADM_TENANTADM_ADDR
           value: http://tenantadm:8080
@@ -170,6 +198,9 @@ spec:
         image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
+{{- if .Values.workflows.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.workflows.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
@@ -188,6 +219,9 @@ spec:
           value: http://useradm:8080
         - name: AUDITLOGS_DEVICEAUTH_ADDRESS
           value: http://deviceauth:8080
+{{- if .Values.auditlogs.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.auditlogs.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: AUDITLOGS_
           secretRef:
@@ -205,6 +239,9 @@ spec:
         image: {{ .Values.iot_manager.image.registry | default "docker.io" }}/{{ .Values.iot_manager.image.repository | default "mendersoftware/iot-manager" }}:{{ .Values.iot_manager.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.iot_manager.image.imagePullPolicy }}
+{{- if .Values.iot_manager.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.iot_manager.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         envFrom:
         - prefix: IOT_MANAGER_
           secretRef:

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -45,6 +45,9 @@ spec:
 {{- if and (eq .Values.global.storage "aws") (.Values.global.s3.AWS_SERVICE_ACCOUNT_NAME) }}
       serviceAccountName: {{ .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}
 {{- end }}
+{{- if .Values.deployments.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.deployments.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
       containers:
       - name: deployments
 {{- if .Values.global.enterprise }}
@@ -53,6 +56,9 @@ spec:
         image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deployments.image.imagePullPolicy }}
+{{- if .Values.deployments.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deployments.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.deployments.resources | indent 10 }}
 

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -42,6 +42,9 @@ spec:
       {{- with .Values.device_auth.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.device_auth.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.device_auth.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: device-auth
@@ -51,6 +54,9 @@ spec:
         image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
+{{- if .Values.device_auth.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.device_auth.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.device_auth.resources | indent 10 }}
 

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.deviceconfig.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.deviceconfig.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.deviceconfig.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: deviceconfig
         image: {{ .Values.deviceconfig.image.registry }}/{{ .Values.deviceconfig.image.repository }}:{{ .Values.deviceconfig.image.tag }}
         imagePullPolicy: {{ .Values.deviceconfig.image.imagePullPolicy }}
+{{- if .Values.deviceconfig.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deviceconfig.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.deviceconfig.resources | indent 10 }}
 

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.deviceconnect.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.deviceconnect.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.deviceconnect.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: deviceconnect
         image: {{ .Values.deviceconnect.image.registry }}/{{ .Values.deviceconnect.image.repository }}:{{ .Values.deviceconnect.image.tag }}
         imagePullPolicy: {{ .Values.deviceconnect.image.imagePullPolicy }}
+{{- if .Values.deviceconnect.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deviceconnect.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.deviceconnect.resources | indent 10 }}
 

--- a/mender/templates/devicemonitor-deploy.yaml
+++ b/mender/templates/devicemonitor-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.devicemonitor.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.devicemonitor.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.devicemonitor.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: devicemonitor
         image: {{ .Values.devicemonitor.image.registry }}/{{ .Values.devicemonitor.image.repository }}:{{ .Values.devicemonitor.image.tag }}
         imagePullPolicy: {{ .Values.devicemonitor.image.imagePullPolicy }}
+{{- if .Values.devicemonitor.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.devicemonitor.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.devicemonitor.resources | indent 10 }}
 

--- a/mender/templates/gui-deploy.yaml
+++ b/mender/templates/gui-deploy.yaml
@@ -42,22 +42,28 @@ spec:
       {{- with .Values.gui.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.gui.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.gui.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: gui
         image: {{ .Values.gui.image.registry }}/{{ .Values.gui.image.repository }}:{{ .Values.gui.image.tag }}
         imagePullPolicy: {{ .Values.gui.image.imagePullPolicy }}
+{{- if .Values.gui.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.gui.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.gui.resources | indent 10 }}
 
         # Readiness/liveness probes
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: {{ .Values.gui.httpPort }}
           periodSeconds: 5
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: {{ .Values.gui.httpPort }}
           periodSeconds: 15
 
         env:

--- a/mender/templates/gui-svc.yaml
+++ b/mender/templates/gui-svc.yaml
@@ -31,7 +31,7 @@ spec:
   ports:
   - port: {{ .Values.gui.service.port }}
     protocol: TCP
-    targetPort: 80
+    targetPort: {{ .Values.gui.httpPort }}
     {{- if .Values.gui.service.nodePort }}
     nodePort: {{ .Values.gui.service.nodePort }}
     {{- end }}

--- a/mender/templates/inventory-deploy.yaml
+++ b/mender/templates/inventory-deploy.yaml
@@ -42,6 +42,9 @@ spec:
       {{- with .Values.inventory.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.inventory.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.inventory.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: inventory
@@ -51,6 +54,9 @@ spec:
         image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.inventory.image.imagePullPolicy }}
+{{- if .Values.inventory.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.inventory.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.inventory.resources | indent 10 }}
 

--- a/mender/templates/iot-manager-deploy.yaml
+++ b/mender/templates/iot-manager-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.iot_manager.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.iot_manager.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.iot_manager.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: iot-manager
         image: {{ .Values.iot_manager.image.registry }}/{{ .Values.iot_manager.image.repository }}:{{ .Values.iot_manager.image.tag }}
         imagePullPolicy: {{ .Values.iot_manager.image.imagePullPolicy }}
+{{- if .Values.iot_manager.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.iot_manager.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.iot_manager.resources | indent 10 }}
 

--- a/mender/templates/redis-deploy.yaml
+++ b/mender/templates/redis-deploy.yaml
@@ -30,11 +30,17 @@ spec:
       {{- with .Values.redis.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.redis.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.redis.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: redis
         image: {{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ .Values.redis.image.imagePullPolicy }}
+{{- if .Values.redis.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.redis.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.redis.resources | indent 10 }}
 

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -42,11 +42,17 @@ spec:
       {{- with .Values.tenantadm.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.tenantadm.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.tenantadm.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: tenantadm
         image: {{ .Values.tenantadm.image.registry }}/{{ .Values.tenantadm.image.repository }}:{{ .Values.tenantadm.image.tag }}
         imagePullPolicy: {{ .Values.tenantadm.image.imagePullPolicy }}
+{{- if .Values.tenantadm.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.tenantadm.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.tenantadm.resources | indent 10 }}
 

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -43,6 +43,9 @@ spec:
       {{- with .Values.useradm.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.useradm.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.useradm.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: useradm
@@ -52,6 +55,9 @@ spec:
         image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
+{{- if .Values.useradm.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.useradm.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.useradm.resources | indent 10 }}
 

--- a/mender/templates/workflows-server-deploy.yaml
+++ b/mender/templates/workflows-server-deploy.yaml
@@ -42,6 +42,9 @@ spec:
       {{- with .Values.workflows.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.workflows.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.workflows.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: workflows
@@ -51,6 +54,9 @@ spec:
         image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
+{{- if .Values.workflows.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.workflows.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.workflows.resources | indent 10 }}
 

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -42,6 +42,9 @@ spec:
       {{- with .Values.workflows.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+{{- if .Values.workflows.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.workflows.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
 
       containers:
       - name: workflows
@@ -51,6 +54,9 @@ spec:
         image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}-worker:{{ .Values.workflows.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
+{{- if .Values.workflows.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.workflows.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.workflows.resources | indent 10 }}
 

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -66,8 +66,8 @@ api_gateway:
       memory: 512M
   affinity: {}
   nodeSelector: {}
-  httpPort: 80
-  httpsPort: 443
+  httpPort: 9080
+  httpsPort: 9443
   service:
     name: mender-api-gateway
     annotations: {}
@@ -87,6 +87,14 @@ api_gateway:
     sourceCriterion:
       ipStrategy:
         depth: 1
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 deployments:
   enabled: true
@@ -115,6 +123,14 @@ deployments:
   env:
     DEPLOYMENTS_MIDDLEWARE: prod
     DEPLOYMENTS_PRESIGN_SECRET: ""
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 device_auth:
   enabled: true
@@ -153,6 +169,14 @@ device_auth:
     DEVICEAUTH_REDIS_TIMEOUT_SEC: "1"
     DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC: "3600"
     DEVICEAUTH_TENANTADM_ADDR: http://mender-tenantadm:8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 generate_delta_worker:
   enabled: true
@@ -197,6 +221,15 @@ gui:
     annotations: {}
     type: ClusterIP
     port: 80
+  httpPort: 80
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 inventory:
   enabled: true
@@ -224,6 +257,14 @@ inventory:
     port: 8080
   env:
     INVENTORY_MIDDLEWARE: prod
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 tenantadm:
   enabled: true
@@ -254,6 +295,14 @@ tenantadm:
     TENANTADM_SERVER_PRIV_KEY_PATH: /etc/tenantadm/rsa/private.pem
     TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
     TENANTADM_RECAPTCHA_URL_VERIFY: https://www.google.com/recaptcha/api/siteverify
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 useradm:
   enabled: true
@@ -292,6 +341,14 @@ useradm:
     USERADM_REDIS_LIMITS_EXPIRE_SEC: "3600"
     USERADM_TENANTADM_ADDR: http://mender-tenantadm:8080
     USERADM_TOTP_ISSUER: Mender
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 workflows:
   enabled: true
@@ -317,6 +374,14 @@ workflows:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 create_artifact_worker:
   enabled: true
@@ -337,6 +402,14 @@ create_artifact_worker:
     tag: mender-3.5.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 auditlogs:
   enabled: true
@@ -362,6 +435,14 @@ auditlogs:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 iot_manager:
   enabled: true
@@ -387,6 +468,14 @@ iot_manager:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 reporting:
   enabled: true
@@ -437,6 +526,14 @@ deviceconnect:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 deviceconfig:
   enabled: true
@@ -462,6 +559,14 @@ deviceconfig:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 devicemonitor:
   enabled: true
@@ -487,6 +592,14 @@ devicemonitor:
     annotations: {}
     type: ClusterIP
     port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
 
 redis:
   enabled: true
@@ -509,6 +622,14 @@ redis:
     annotations: {}
     type: ClusterIP
     port: 6379
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 999
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 999
 
 dbmigration:
   enable: true
@@ -516,3 +637,7 @@ dbmigration:
   backoffLimit: 5
   affinity: {}
   nodeSelector: {}
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 999


### PR DESCRIPTION
This PR adds support for `securityContext` in both the pod and container spec. 

The newly added values each have an `enabled` switch, which is disabled by default for backward compatibility.

For the `api_gateway` securityContext to work, the internal listening ports have been moved out of the privileged port range.

The `gui` container can not work without upstream adjustments of the container image. Currently, the port used by nginx is fixed to `80`. I added `gui.httpPort` to be able to change the port when it gets configurable in the `gui` image.

Documentation for all added parameters is provided as well. 

Let me know if you require any adjustments.