### PR TITLE
fix smtp configuration according to the config.yaml in workflows repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ The following table lists the global parameters supported by the chart and their
 | `global.azure.AUTH_SHARED_KEY_URI` | Azure Blob Storage shared key URI | `""` |
 | `global.azure.CONTAINER_NAME` | Azure Blob Storage container name | `mender-artifact-storage` |
 | `global.smtp.EMAIL_SENDER` | SMTP email sender | `root@localhost` |
-| `global.smtp.SMTP_ADDRESS` | SMTP server address | `smtp.mailtrap.io` |
-| `global.smtp.SMTP_LOGIN` | SMTP server username | `null` |
+| `global.smtp.SMTP_HOST` | SMTP server address | `localhost:25` |
+| `global.smtp.SMTP_AUTH_MECHANISM` | SMTP auth mechanism (Valid values: PLAIN, CRAM-MD5) | `PLAIN` |
+| `global.smtp.SMTP_USERNAME` | SMTP server username | `null` |
 | `global.smtp.SMTP_PASSWORD` | SMTP server password | `null` |
 | `global.smtp.SMTP_SSL` | Enable the SSL connection to the SMTP server | `false` |
 | `global.url` | Public URL of the Mender Server, replace with your domain | `https://mender-api-gateway` |

--- a/mender/templates/secret-smtp.yaml
+++ b/mender/templates/secret-smtp.yaml
@@ -12,7 +12,8 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 data:
   EMAIL_SENDER: {{ .Values.global.smtp.EMAIL_SENDER | b64enc }}
-  SMTP_ADDRESS: {{ .Values.global.smtp.SMTP_ADDRESS | b64enc }}
-  SMTP_LOGIN: {{ .Values.global.smtp.SMTP_LOGIN | b64enc }}
+  SMTP_HOST: {{ .Values.global.smtp.SMTP_HOST | b64enc }}
+  SMTP_AUTH_MECHANISM: {{ .Values.global.smtp.SMTP_AUTH_MECHANISM | b64enc }}
+  SMTP_USERNAME: {{ .Values.global.smtp.SMTP_USERNAME | b64enc }}
   SMTP_PASSWORD: {{ .Values.global.smtp.SMTP_PASSWORD | b64enc }}
   SMTP_SSL: {{ .Values.global.smtp.SMTP_SSL | b64enc }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -31,8 +31,9 @@ global:
     CONTAINER_NAME: mender-artifact-storage
   smtp:
     EMAIL_SENDER: root@localhost
-    SMTP_ADDRESS: "localhost:25"
-    SMTP_LOGIN: "null"
+    SMTP_HOST: "localhost:25"
+    SMTP_AUTH_MECHANISM: "PLAIN"
+    SMTP_USERNAME: "null"
     SMTP_PASSWORD: "null"
     SMTP_SSL: "false"
   url: "https://mender-api-gateway"
@@ -53,7 +54,6 @@ dataMigration:
     affinity: {}
     nodeSelector: {}
     tolerations: {}
-
 
 api_gateway:
   enabled: true


### PR DESCRIPTION
This PR updates the STMP configuration to match what is defined in the [config.yaml of the workflows repo](https://github.com/mendersoftware/workflows/blob/master/config.yaml#L72-L95)..

Also, I couldn't find where `EMAIL_SENDER` and `SMTP_SSL` is being used.. are these still supported?