### PR TITLE
Update Chart and AppVersion to 3.5.1

### DIFF
--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "3.5.0"
+appVersion: "3.5.1"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: "3.5.0"
+version: "3.5.1"
 keywords:
 - mender
 - iot


### PR DESCRIPTION
As the Mender 3.5.1 version is out and the [documentation](https://docs.mender.io/3.5/server-installation/production-installation-with-kubernetes/mender-server) is already referring to it, I'm bumping the chart version and the AppVersion.