### PR TITLE
Global registry.image.tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following table lists the global parameters supported by the chart and their
 | `global.image.registry` | Global Docker image registry | `registry.mender.io` |
 | `global.image.username` | Global Docker image registry username | `nil` |
 | `global.image.password` | Global Docker image registry username | `password` |
+| `global.image.tag` | Global Docker image registry tag | `mender-3.4` |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |
 | `global.nats.URL` | NATS URL | `nats://nats:4222` |
@@ -173,13 +174,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install my-release \
   --set mongodbRootPassword=secretpassword,mongodbUsername=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
-  ./mender-3.5.0.tgz
+  ./mender
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml ./mender-3.5.0.tgz
+$ helm install --name my-release -f values.yaml ./mender
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -239,7 +240,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deployments.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `deployments.image.repository` | Docker image repository | `mendersoftware/deployments-enterprise` if `global.enterprise` is true, else `mendersoftware/deployments` |
-| `deployments.image.tag` | Docker image tag | `mender-3.5.0` |
+| `deployments.image.tag` | Docker image tag | `nil` |
 | `deployments.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deployments.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deployments.podAnnotations` | add custom pod annotations | `nil` |
@@ -278,7 +279,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `device_auth.image.registry` | Docker image registry | `docker.io` |
 | `device_auth.image.repository` | Docker image repository | `mendersoftware/deviceauth` |
-| `device_auth.image.tag` | Docker image tag | `mender-3.5.0` |
+| `device_auth.image.tag` | Docker image tag | `nil` |
 | `device_auth.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `device_auth.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `device_auth.podAnnotations` | add custom pod annotations | `nil` |
@@ -323,7 +324,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.enabled` | Enable the component | `true` |
 | `gui.image.registry` | Docker image registry | `docker.io` |
 | `gui.image.repository` | Docker image repository | `mendersoftware/gui` |
-| `gui.image.tag` | Docker image tag | `mender-3.5.0` |
+| `gui.image.tag` | Docker image tag | `nil` |
 | `gui.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `gui.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `gui.podAnnotations` | add custom pod annotations | `nil` |
@@ -358,7 +359,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `inventory.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `inventory.image.repository` | Docker image repository | `mendersoftware/inventory-enterprise` if `global.enterprise` is true, else `mendersoftware/inventory` |
-| `inventory.image.tag` | Docker image tag | `mender-3.5.0` |
+| `inventory.image.tag` | Docker image tag | `nil` |
 | `inventory.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `inventory.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `inventory.podAnnotations` | add custom pod annotations | `nil` |
@@ -393,7 +394,7 @@ The following table lists the parameters for the `reporting` component and their
 | `reporting.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `reporting.image.registry` | Docker image registry | `docker.io` |
 | `reporting.image.repository` | Docker image repository | `mendersoftware/reporting` |
-| `reporting.image.tag` | Docker image tag | `mender-3.5.0` |
+| `reporting.image.tag` | Docker image tag | `nil` |
 | `reporting.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `reporting.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `reporting.image.podAnnotations` | add custom pod annotations | `nil` |
@@ -420,7 +421,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.enabled` | Enable the component | `true` |
 | `tenantadm.image.registry` | Docker image registry | `registry.mender.io` |
 | `tenantadm.image.repository` | Docker image repository | `mendersoftware/tenantadm` |
-| `tenantadm.image.tag` | Docker image tag | `mender-3.5.0` |
+| `tenantadm.image.tag` | Docker image tag | `nil` |
 | `tenantadm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `tenantadm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `tenantadm.podAnnotations` | add custom pod annotations | `nil` |
@@ -469,7 +470,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `useradm.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `useradm.image.repository` | Docker image repository | `mendersoftware/useradm-enterprise` if `global.enterprise` is true, else `mendersoftware/useradm` |
-| `useradm.image.tag` | Docker image tag | `mender-3.5.0` |
+| `useradm.image.tag` | Docker image tag | `nil` |
 | `useradm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `useradm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `useradm.podAnnotations` | add custom pod annotations | `nil` |
@@ -515,7 +516,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `workflows.image.registry` | Docker image registry | `registry.mender.io` if `global.enterprise` is true, else `docker.io` |
 | `workflows.image.repository` | Docker image repository | `mendersoftware/workflows-enterprise` if `global.enterprise` is true, else `mendersoftware/workflows` |
-| `workflows.image.tag` | Docker image tag | `mender-3.5.0` |
+| `workflows.image.tag` | Docker image tag | `nil` |
 | `workflows.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `workflows.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `workflows.podAnnotations` | add custom pod annotations | `nil` |
@@ -549,7 +550,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `create_artifact_worker.image.registry` | Docker image registry | `docker.io` |
 | `create_artifact_worker.image.repository` | Docker image repository | `mendersoftware/create-artifact-worker` |
-| `create_artifact_worker.image.tag` | Docker image tag | `mender-3.5.0` |
+| `create_artifact_worker.image.tag` | Docker image tag | `nil` |
 | `create_artifact_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `create_artifact_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `create_artifact_worker.podAnnotations` | add custom pod annotations | `nil` |
@@ -576,7 +577,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `auditlogs.image.registry` | Docker image registry | `registry.mender.io` |
 | `auditlogs.image.repository` | Docker image repository | `mendersoftware/auditlogs` |
-| `auditlogs.image.tag` | Docker image tag | `mender-3.5.0` |
+| `auditlogs.image.tag` | Docker image tag | `nil` |
 | `auditlogs.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `auditlogs.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `auditlogs.podAnnotations` | add custom pod annotations | `nil` |
@@ -610,7 +611,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `iot_manager.image.registry` | Docker image registry | `docker.io` |
 | `iot_manager.image.repository` | Docker image repository | `mendersoftware/iot-manager` |
-| `iot_manager.image.tag` | Docker image tag | `mender-3.5.0` |
+| `iot_manager.image.tag` | Docker image tag | `nil` |
 | `iot_manager.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `iot_manager.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `iot_manager.image.podAnnotations` | add custom pod annotations | `nil` |
@@ -644,7 +645,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deviceconnect.image.registry` | Docker image registry | `docker.io` |
 | `deviceconnect.image.repository` | Docker image repository | `mendersoftware/deviceconnect` |
-| `deviceconnect.image.tag` | Docker image tag | `mender-3.5.0` |
+| `deviceconnect.image.tag` | Docker image tag | `nil` |
 | `deviceconnect.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deviceconnect.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconnect.podAnnotations` | add custom pod annotations | `nil` |
@@ -678,7 +679,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `deviceconfig.image.registry` | Docker image registry | `docker.io` |
 | `deviceconfig.image.repository` | Docker image repository | `mendersoftware/deviceconfig` |
-| `deviceconfig.image.tag` | Docker image tag | `mender-3.5.0` |
+| `deviceconfig.image.tag` | Docker image tag | `nil` |
 | `deviceconfig.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `deviceconfig.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconfig.podAnnotations` | add custom pod annotations | `nil` |
@@ -712,7 +713,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `devicemonitor.image.registry` | Docker image registry | `registry.mender.io` |
 | `devicemonitor.image.repository` | Docker image repository | `mendersoftware/devicemonitor` |
-| `devicemonitor.image.tag` | Docker image tag | `mender-3.5.0` |
+| `devicemonitor.image.tag` | Docker image tag | `nil` |
 | `devicemonitor.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `devicemonitor.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `devicemonitor.podAnnotations` | add custom pod annotations | `nil` |
@@ -750,7 +751,7 @@ The following table lists the parameters for the `generate-delta-worker` compone
 | `generate_delta_worker.automigrate` | Enable automatic database migrations at service start up | `true` |
 | `generate_delta_worker.image.registry` | Docker image registry | `registry.mender.io` |
 | `generate_delta_worker.image.repository` | Docker image repository | `mendersoftware/generate-delta-worker` |
-| `generate_delta_worker.image.tag` | Docker image tag | `mender-3.5.0` |
+| `generate_delta_worker.image.tag` | Docker image tag | `nil` |
 | `generate_delta_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `generate_delta_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `generate_delta_worker.podAnnotations` | add custom pod annotations | `nil` |

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+# Version 4.0.1
+* Using global `registry.image.tag` instead of specifying it in every deployment
+
 # Version 4.0.0
 * **BREAKING CHANGE**: drop Helm v2 support: bump Helm ApiVersion to v2.
 * Decoupling Helm Chart version (`version: 4.0.0`) from Mender version (`appVersion: "3.4.0"`): from now on, they can be updated independently.

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.4.0"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 4.0.0
+version: 4.0.1
 keywords:
 - mender
 - iot

--- a/mender/templates/auditlogs-deploy.yaml
+++ b/mender/templates/auditlogs-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: auditlogs
-        image: {{ .Values.auditlogs.image.registry }}/{{ .Values.auditlogs.image.repository }}:{{ .Values.auditlogs.image.tag }}
+        image: {{ .Values.auditlogs.image.registry }}/{{ .Values.auditlogs.image.repository }}:{{ .Values.auditlogs.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.auditlogs.image.imagePullPolicy }}
 {{- if .Values.auditlogs.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.auditlogs.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/create-artifact-worker-deploy.yaml
+++ b/mender/templates/create-artifact-worker-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: workflows
-        image: {{ .Values.create_artifact_worker.image.registry }}/{{ .Values.create_artifact_worker.image.repository }}:{{ .Values.create_artifact_worker.image.tag }}
+        image: {{ .Values.create_artifact_worker.image.registry }}/{{ .Values.create_artifact_worker.image.repository }}:{{ .Values.create_artifact_worker.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.create_artifact_worker.image.imagePullPolicy }}
 {{- if .Values.create_artifact_worker.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.create_artifact_worker.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/db-migration-job.yaml
+++ b/mender/templates/db-migration-job.yaml
@@ -45,7 +45,7 @@ spec:
 
 {{- if .Values.global.enterprise }}
       - name: tenantadm-migration
-        image: {{ .Values.tenantadm.image.registry | default "registry.mender.io" }}/{{ .Values.tenantadm.image.repository | default "mendersoftware/tenantadm-enterprise" }}:{{ .Values.tenantadm.image.tag }}
+        image: {{ .Values.tenantadm.image.registry | default "registry.mender.io" }}/{{ .Values.tenantadm.image.repository | default "mendersoftware/tenantadm-enterprise" }}:{{ .Values.tenantadm.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.tenantadm.image.imagePullPolicy }}
 {{- if .Values.tenantadm.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.tenantadm.containerSecurityContext "enabled" | toYaml | nindent 10 }}
@@ -62,9 +62,9 @@ spec:
 
       - name: deployments-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag }}
+        image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag }}
+        image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deployments.image.imagePullPolicy }}
 {{- if .Values.deployments.containerSecurityContext.enabled }}
@@ -82,9 +82,9 @@ spec:
 
       - name: device-auth-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag }}
+        image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag }}
+        image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.device_auth.image.imagePullPolicy }}
 {{- if .Values.device_auth.containerSecurityContext.enabled }}
@@ -102,9 +102,9 @@ spec:
 
       - name: deviceconfig-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.deviceconfig.image.registry | default "registry.mender.io" }}/{{ .Values.deviceconfig.image.repository | default "mendersoftware/deviceconfig-enterprise" }}:{{ .Values.deviceconfig.image.tag }}
+        image: {{ .Values.deviceconfig.image.registry | default "registry.mender.io" }}/{{ .Values.deviceconfig.image.repository | default "mendersoftware/deviceconfig-enterprise" }}:{{ .Values.deviceconfig.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.deviceconfig.image.registry | default "docker.io" }}/{{ .Values.deviceconfig.image.repository | default "mendersoftware/deviceconfig" }}:{{ .Values.deviceconfig.image.tag }}
+        image: {{ .Values.deviceconfig.image.registry | default "docker.io" }}/{{ .Values.deviceconfig.image.repository | default "mendersoftware/deviceconfig" }}:{{ .Values.deviceconfig.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deviceconfig.image.imagePullPolicy }}
 {{- if .Values.deviceconfig.containerSecurityContext.enabled }}
@@ -121,7 +121,7 @@ spec:
 
 {{- if .Values.global.enterprise }}
       - name: devicemonitor-migration
-        image: {{ .Values.devicemonitor.image.registry | default "registry.mender.io" }}/{{ .Values.devicemonitor.image.repository | default "mendersoftware/devicemonitor-enterprise" }}:{{ .Values.devicemonitor.image.tag }}
+        image: {{ .Values.devicemonitor.image.registry | default "registry.mender.io" }}/{{ .Values.devicemonitor.image.repository | default "mendersoftware/devicemonitor-enterprise" }}:{{ .Values.devicemonitor.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.devicemonitor.image.imagePullPolicy }}
 {{- if .Values.devicemonitor.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.devicemonitor.containerSecurityContext "enabled" | toYaml | nindent 10 }}
@@ -138,9 +138,9 @@ spec:
 
       - name: deviceconnect-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.deviceconnect.image.registry | default "registry.mender.io" }}/{{ .Values.deviceconnect.image.repository | default "mendersoftware/deviceconnect-enterprise" }}:{{ .Values.deviceconnect.image.tag }}
+        image: {{ .Values.deviceconnect.image.registry | default "registry.mender.io" }}/{{ .Values.deviceconnect.image.repository | default "mendersoftware/deviceconnect-enterprise" }}:{{ .Values.deviceconnect.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.deviceconnect.image.registry | default "docker.io" }}/{{ .Values.deviceconnect.image.repository | default "mendersoftware/deviceconnect" }}:{{ .Values.deviceconnect.image.tag }}
+        image: {{ .Values.deviceconnect.image.registry | default "docker.io" }}/{{ .Values.deviceconnect.image.repository | default "mendersoftware/deviceconnect" }}:{{ .Values.deviceconnect.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deviceconnect.image.imagePullPolicy }}
 {{- if .Values.deviceconnect.containerSecurityContext.enabled }}
@@ -157,9 +157,9 @@ spec:
 
       - name: inventory-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.inventory.image.registry | default "registry.mender.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory-enterprise" }}:{{ .Values.inventory.image.tag }}
+        image: {{ .Values.inventory.image.registry | default "registry.mender.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory-enterprise" }}:{{ .Values.inventory.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag }}
+        image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.inventory.image.imagePullPolicy }}
 {{- if .Values.inventory.containerSecurityContext.enabled }}
@@ -176,9 +176,9 @@ spec:
 
       - name: useradm-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.useradm.image.registry | default "registry.mender.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm-enterprise" }}:{{ .Values.useradm.image.tag }}
+        image: {{ .Values.useradm.image.registry | default "registry.mender.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm-enterprise" }}:{{ .Values.useradm.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag }}
+        image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
 {{- if .Values.useradm.containerSecurityContext.enabled }}
@@ -197,9 +197,9 @@ spec:
 
       - name: workflows-server-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
 {{- if .Values.workflows.containerSecurityContext.enabled }}
@@ -216,7 +216,7 @@ spec:
 
 {{- if .Values.global.enterprise }}
       - name: auditlogs-migration
-        image: {{ .Values.auditlogs.image.registry | default "registry.mender.io" }}/{{ .Values.auditlogs.image.repository | default "mendersoftware/auditlogs-enterprise" }}:{{ .Values.auditlogs.image.tag }}
+        image: {{ .Values.auditlogs.image.registry | default "registry.mender.io" }}/{{ .Values.auditlogs.image.repository | default "mendersoftware/auditlogs-enterprise" }}:{{ .Values.auditlogs.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.auditlogs.image.imagePullPolicy }}
         env:
         - name: AUDITLOGS_USERADM_ADDRESS
@@ -238,9 +238,9 @@ spec:
 
       - name: iot-manager-migration
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.iot_manager.image.registry | default "registry.mender.io" }}/{{ .Values.iot_manager.image.repository | default "mendersoftware/iot-manager-enterprise" }}:{{ .Values.iot_manager.image.tag }}
+        image: {{ .Values.iot_manager.image.registry | default "registry.mender.io" }}/{{ .Values.iot_manager.image.repository | default "mendersoftware/iot-manager-enterprise" }}:{{ .Values.iot_manager.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.iot_manager.image.registry | default "docker.io" }}/{{ .Values.iot_manager.image.repository | default "mendersoftware/iot-manager" }}:{{ .Values.iot_manager.image.tag }}
+        image: {{ .Values.iot_manager.image.registry | default "docker.io" }}/{{ .Values.iot_manager.image.repository | default "mendersoftware/iot-manager" }}:{{ .Values.iot_manager.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.iot_manager.image.imagePullPolicy }}
 {{- if .Values.iot_manager.containerSecurityContext.enabled }}

--- a/mender/templates/deployments-deploy.yaml
+++ b/mender/templates/deployments-deploy.yaml
@@ -55,9 +55,9 @@ spec:
       containers:
       - name: deployments
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag }}
+        image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag }}
+        image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.deployments.image.imagePullPolicy }}
 {{- if .Values.deployments.containerSecurityContext.enabled }}

--- a/mender/templates/deployments-storage-daemon-cronjob.yaml
+++ b/mender/templates/deployments-storage-daemon-cronjob.yaml
@@ -37,9 +37,9 @@ spec:
           containers:
           - name: deployments-storage-daemon
             {{- if .Values.global.enterprise }}
-            image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag }}
+            image: {{ .Values.deployments.image.registry | default "registry.mender.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments-enterprise" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
             {{- else }}
-            image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag }}
+            image: {{ .Values.deployments.image.registry | default "docker.io" }}/{{ .Values.deployments.image.repository | default "mendersoftware/deployments" }}:{{ .Values.deployments.image.tag | default .Values.global.image.tag }}
             {{- end }}
             args: ["storage-daemon"]
             env:

--- a/mender/templates/device-auth-cron-license-count.yaml
+++ b/mender/templates/device-auth-cron-license-count.yaml
@@ -30,7 +30,7 @@ spec:
           {{- end }}
           containers:
           - name: device-auth-license-count
-            image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag }}
+            image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag | default .Values.global.image.tag }}
             command: ["/usr/bin/deviceauth-enterprise", "license-count"]
 
             envFrom:

--- a/mender/templates/device-auth-deploy.yaml
+++ b/mender/templates/device-auth-deploy.yaml
@@ -53,9 +53,9 @@ spec:
       containers:
       - name: device-auth
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag }}
+        image: {{ .Values.device_auth.image.registry | default "registry.mender.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth-enterprise" }}:{{ .Values.device_auth.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag }}
+        image: {{ .Values.device_auth.image.registry | default "docker.io" }}/{{ .Values.device_auth.image.repository | default "mendersoftware/deviceauth" }}:{{ .Values.device_auth.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
 {{- if .Values.device_auth.containerSecurityContext.enabled }}

--- a/mender/templates/deviceconfig-deploy.yaml
+++ b/mender/templates/deviceconfig-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: deviceconfig
-        image: {{ .Values.deviceconfig.image.registry }}/{{ .Values.deviceconfig.image.repository }}:{{ .Values.deviceconfig.image.tag }}
+        image: {{ .Values.deviceconfig.image.registry }}/{{ .Values.deviceconfig.image.repository }}:{{ .Values.deviceconfig.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.deviceconfig.image.imagePullPolicy }}
 {{- if .Values.deviceconfig.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.deviceconfig.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/deviceconnect-deploy.yaml
+++ b/mender/templates/deviceconnect-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: deviceconnect
-        image: {{ .Values.deviceconnect.image.registry }}/{{ .Values.deviceconnect.image.repository }}:{{ .Values.deviceconnect.image.tag }}
+        image: {{ .Values.deviceconnect.image.registry }}/{{ .Values.deviceconnect.image.repository }}:{{ .Values.deviceconnect.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.deviceconnect.image.imagePullPolicy }}
 {{- if .Values.deviceconnect.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.deviceconnect.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/devicemonitor-deploy.yaml
+++ b/mender/templates/devicemonitor-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: devicemonitor
-        image: {{ .Values.devicemonitor.image.registry }}/{{ .Values.devicemonitor.image.repository }}:{{ .Values.devicemonitor.image.tag }}
+        image: {{ .Values.devicemonitor.image.registry }}/{{ .Values.devicemonitor.image.repository }}:{{ .Values.devicemonitor.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.devicemonitor.image.imagePullPolicy }}
 {{- if .Values.devicemonitor.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.devicemonitor.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/generate-delta-worker-deploy.yaml
+++ b/mender/templates/generate-delta-worker-deploy.yaml
@@ -49,7 +49,7 @@ spec:
 
       containers:
       - name: workflows
-        image: {{ .Values.generate_delta_worker.image.registry }}/{{ .Values.generate_delta_worker.image.repository }}:{{ .Values.generate_delta_worker.image.tag }}
+        image: {{ .Values.generate_delta_worker.image.registry }}/{{ .Values.generate_delta_worker.image.repository }}:{{ .Values.generate_delta_worker.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.generate_delta_worker.image.imagePullPolicy }}
         resources:
 {{ toYaml .Values.generate_delta_worker.resources | indent 10 }}

--- a/mender/templates/gui-deploy.yaml
+++ b/mender/templates/gui-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: gui
-        image: {{ .Values.gui.image.registry }}/{{ .Values.gui.image.repository }}:{{ .Values.gui.image.tag }}
+        image: {{ .Values.gui.image.registry }}/{{ .Values.gui.image.repository }}:{{ .Values.gui.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.gui.image.imagePullPolicy }}
 {{- if .Values.gui.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.gui.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/inventory-deploy.yaml
+++ b/mender/templates/inventory-deploy.yaml
@@ -53,9 +53,9 @@ spec:
       containers:
       - name: inventory
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.inventory.image.registry | default "registry.mender.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory-enterprise" }}:{{ .Values.inventory.image.tag }}
+        image: {{ .Values.inventory.image.registry | default "registry.mender.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory-enterprise" }}:{{ .Values.inventory.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag }}
+        image: {{ .Values.inventory.image.registry | default "docker.io" }}/{{ .Values.inventory.image.repository | default "mendersoftware/inventory" }}:{{ .Values.inventory.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.inventory.image.imagePullPolicy }}
 {{- if .Values.inventory.containerSecurityContext.enabled }}

--- a/mender/templates/iot-manager-deploy.yaml
+++ b/mender/templates/iot-manager-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: iot-manager
-        image: {{ .Values.iot_manager.image.registry }}/{{ .Values.iot_manager.image.repository }}:{{ .Values.iot_manager.image.tag }}
+        image: {{ .Values.iot_manager.image.registry }}/{{ .Values.iot_manager.image.repository }}:{{ .Values.iot_manager.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.iot_manager.image.imagePullPolicy }}
 {{- if .Values.iot_manager.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.iot_manager.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/tenantadm-deploy.yaml
+++ b/mender/templates/tenantadm-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 
       containers:
       - name: tenantadm
-        image: {{ .Values.tenantadm.image.registry }}/{{ .Values.tenantadm.image.repository }}:{{ .Values.tenantadm.image.tag }}
+        image: {{ .Values.tenantadm.image.registry }}/{{ .Values.tenantadm.image.repository }}:{{ .Values.tenantadm.image.tag | default .Values.global.image.tag }}
         imagePullPolicy: {{ .Values.tenantadm.image.imagePullPolicy }}
 {{- if .Values.tenantadm.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.tenantadm.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/mender/templates/useradm-deploy.yaml
+++ b/mender/templates/useradm-deploy.yaml
@@ -54,9 +54,9 @@ spec:
       containers:
       - name: useradm
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.useradm.image.registry | default "registry.mender.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm-enterprise" }}:{{ .Values.useradm.image.tag }}
+        image: {{ .Values.useradm.image.registry | default "registry.mender.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm-enterprise" }}:{{ .Values.useradm.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag }}
+        image: {{ .Values.useradm.image.registry | default "docker.io" }}/{{ .Values.useradm.image.repository | default "mendersoftware/useradm" }}:{{ .Values.useradm.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.useradm.image.imagePullPolicy }}
 {{- if .Values.useradm.containerSecurityContext.enabled }}

--- a/mender/templates/workflows-server-deploy.yaml
+++ b/mender/templates/workflows-server-deploy.yaml
@@ -53,9 +53,9 @@ spec:
       containers:
       - name: workflows
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
 {{- if .Values.workflows.containerSecurityContext.enabled }}

--- a/mender/templates/workflows-worker-deploy.yaml
+++ b/mender/templates/workflows-worker-deploy.yaml
@@ -53,9 +53,9 @@ spec:
       containers:
       - name: workflows
 {{- if .Values.global.enterprise }}
-        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}-worker:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "registry.mender.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows-enterprise" }}-worker:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- else }}
-        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}-worker:{{ .Values.workflows.image.tag }}
+        image: {{ .Values.workflows.image.registry | default "docker.io" }}/{{ .Values.workflows.image.repository | default "mendersoftware/workflows" }}-worker:{{ .Values.workflows.image.tag | default .Values.global.image.tag }}
 {{- end }}
         imagePullPolicy: {{ .Values.workflows.image.imagePullPolicy }}
 {{- if .Values.workflows.containerSecurityContext.enabled }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -6,6 +6,7 @@ global:
     registry: registry.mender.io
     username: null
     password: null
+    tag: mender-3.4
   mongodb:
     URL: mongodb://mongodb
   nats:
@@ -112,7 +113,6 @@ deployments:
   image:
     registry: ""
     repository: ""
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -148,7 +148,6 @@ device_auth:
   image:
     registry: ""
     repository: ""
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -216,7 +215,6 @@ gui:
   image:
     registry: docker.io
     repository: mendersoftware/gui
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -250,7 +248,6 @@ inventory:
   image:
     registry: ""
     repository: ""
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -284,7 +281,6 @@ tenantadm:
   image:
     registry: registry.mender.io
     repository: mendersoftware/tenantadm
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -323,7 +319,6 @@ useradm:
   image:
     registry: ""
     repository: ""
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -369,7 +364,6 @@ workflows:
   image:
     registry: ""
     repository: ""
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -402,7 +396,6 @@ create_artifact_worker:
   image:
     registry: docker.io
     repository: mendersoftware/create-artifact-worker
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   podSecurityContext:
@@ -430,7 +423,6 @@ auditlogs:
   image:
     registry: registry.mender.io
     repository: mendersoftware/auditlogs
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -463,7 +455,6 @@ iot_manager:
   image:
     registry: docker.io
     repository: mendersoftware/iot-manager
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -496,7 +487,6 @@ deviceconnect:
   image:
     registry: docker.io
     repository: mendersoftware/deviceconnect
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -529,7 +519,6 @@ deviceconfig:
   image:
     registry: docker.io
     repository: mendersoftware/deviceconfig
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:
@@ -562,7 +551,6 @@ devicemonitor:
   image:
     registry: registry.mender.io
     repository: mendersoftware/devicemonitor
-    tag: mender-3.4.0
     imagePullPolicy: IfNotPresent
   nodeSelector: {}
   service:


### PR DESCRIPTION
Using a `global.registry.image.tag` for Mender deployment (defult to `mender-3.4`) so to not specify it in every deployment.
This leads also a better user experience with selecting a different Mender version within the same Helm Chart.

Ticket: https://northerntech.atlassian.net/browse/MC-6798