### PR TITLE
fix: device-auth-license-count ImagePullBackOff

### DIFF
--- a/mender/templates/device-auth-cron-license-count.yaml
+++ b/mender/templates/device-auth-cron-license-count.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.device_auth.enabled }}
+{{- if and (.Values.device_auth.enabled) (.Values.global.enterprise) }}
 {{- $merged := merge (deepCopy .Values.device_auth) (deepCopy (default (dict) .Values.default)) -}}
 apiVersion: batch/v1
 kind: CronJob

--- a/mender/templates/device-auth-cron-license-count.yaml
+++ b/mender/templates/device-auth-cron-license-count.yaml
@@ -1,4 +1,5 @@
-{{- if and (.Values.device_auth.enabled) (.Values.global.enterprise) }}
+{{- if and (.Values.device_auth.enabled) (.Values.global.enterprise)
+           (.Values.device_license_count.enabled) }}
 {{- $merged := merge (deepCopy .Values.device_auth) (deepCopy (default (dict) .Values.default)) -}}
 apiVersion: batch/v1
 kind: CronJob

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -607,3 +607,9 @@ dbmigration:
     enabled: false
     runAsNonRoot: true
     runAsUser: 999
+
+# Feature preview: Device License Count
+# Only available from version 3.6,
+# and available in Mender Enterprise
+device_license_count:
+  enabled: false


### PR DESCRIPTION
Per the 3.5.x documentation [1], Device License Count is only available with Enterprise.

Avoid ImagePullBackOff and ErrImagePull by not deploying the device-auth-license-count cron job when global.enterprise is disabled.

[1] https://github.com/mendersoftware/mender-docs/blob/3.5.x/07.Server-installation/07.Device-license-count/docs.md