### PR TITLE
chore: Skip updating NATS consumer in data migration job

### DIFF
--- a/mender/templates/db-migration-job.yaml
+++ b/mender/templates/db-migration-job.yaml
@@ -35,7 +35,7 @@ spec:
 {{- if .Values.dbmigration.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.dbmigration.podSecurityContext "enabled" | toYaml | nindent 8 }}
 {{- end }}
-      
+
 {{- if .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}
       serviceAccountName: {{ .Values.global.s3.AWS_SERVICE_ACCOUNT_NAME }}
 {{- end }}
@@ -211,7 +211,7 @@ spec:
             name: mongodb-common-prerelease
         resources:
 {{ toYaml .Values.workflows.resources | indent 10 }}
-        args: ["migrate"]
+        args: ["migrate", "--skip-nats"]
 
 
 {{- if .Values.global.enterprise }}


### PR DESCRIPTION
After adding the possiblity to migrate the NATS consumer configuration, this might break forward compatibility for older versions which prevents downgrading. Since the newer version works with consumer configurations from older versions we don't force consumer reconfigurations in this job.