### PR TITLE
Backward compatible AWS_BUCKET variable

### DIFF
--- a/mender/templates/secret-artifacts-storage.yaml
+++ b/mender/templates/secret-artifacts-storage.yaml
@@ -14,6 +14,7 @@ data:
 {{- if eq .Values.global.storage "aws" }}
   AWS_URI: {{ .Values.global.s3.AWS_URI | default .Values.global.url | default (ternary (printf "https://%s" .Values.api_gateway.service.name ) (printf "http://%s" .Values.api_gateway.service.name) (.Values.api_gateway.env.SSL)) | b64enc }}
   AWS_BUCKET: {{ .Values.global.s3.AWS_BUCKET | b64enc }}
+  STORAGE_BUCKET: {{ .Values.global.s3.AWS_BUCKET | b64enc }}
   {{- if .Values.global.s3.AWS_EXTERNAL_URI }}
   AWS_EXTERNAL_URI: {{ .Values.global.s3.AWS_EXTERNAL_URI | b64enc }}
   {{- end }}


### PR DESCRIPTION
Ticket: MC-6482

`STORAGE_BUCKET` is going to replace the old `AWS_BUCKET` variable, but this is still used on old deployments.
Adding both AWS_BUCKET and STORAGE_BUCKET vars to the `secret-artifacts-storage.yaml` to have backward compatiblity