### PR TITLE
Conditionally redirect middleware

### DIFF
--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{/*
+Define Mender Major and minor version
+to be able to apply some conditional logic
+*/}}
+{{- define "menderVersionMinor" }}
+{{- with .Values.global.image }}
+{{- if contains "-" .tag }}
+  {{- $mndr_splitted := split "-" .tag -}}
+  {{- $mndr_version := split "." $mndr_splitted._1 }}
+  {{- printf "%s" $mndr_version._1 }}
+{{- else }}
+  {{- $mndr_version := split "." .tag }}
+  {{- printf "%s" $mndr_version._1 }}
+{{- end }}
+{{- end }} 
+{{- end }}
+
+{{- define "menderVersionMajor" }}
+{{- with .Values.global.image }}
+{{- if contains "-" .tag }}
+  {{- $mndr_splitted := split "-" .tag -}}
+  {{- $mndr_version := split "." $mndr_splitted._1 }}
+  {{- printf "%s" $mndr_version._0 }}
+{{- else }}
+  {{- $mndr_version := split "." .tag }}
+  {{- printf "%s" $mndr_version._0 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/mender/templates/api-gateway-configmap.yaml
+++ b/mender/templates/api-gateway-configmap.yaml
@@ -229,6 +229,17 @@ data:
           entrypoints: {{ $scheme }}
           middlewares:
           - ratelimit
+{{- if and ( le (int (include "menderVersionMajor" .)) 3 ) ( le (int (include "menderVersionMinor" .)) 4 ) }}
+          #
+          # redirection rules valid up to 3.4 version
+          #
+          - ensure-ui-path
+          - signup-redirect
+          - ui-stripprefix
+          #
+          # end of redirection rules valid up to 3.4 version
+          #
+{{- end }}
           - userauth
           - sec-headers
           - compression
@@ -457,10 +468,41 @@ data:
       # Middlewares
       #
       middlewares:
+{{- if and ( le (int (include "menderVersionMajor" .)) 3 ) ( le (int (include "menderVersionMinor" .)) 4 ) }}
+        #
+        # redirection rules valid up to 3.4 version
+        #
+        ui-stripprefix:
+          stripprefix:
+            prefixes: "/ui"
+        #
+        # end of redirection rules valid up to 3.4 version
+        #
+{{- end }}
 {{- if .Values.api_gateway.env.SSL }}
         redirect-to-https:
           redirectscheme:
             scheme: https
+{{- end }}
+{{- if and ( le (int (include "menderVersionMajor" .)) 3 ) ( le (int (include "menderVersionMinor" .)) 4 ) }}
+
+        #
+        # redirection rules valid up to 3.4 version
+        #
+        ensure-ui-path:
+          redirectregex:
+            regex: "^({{ $scheme }}?://[^/]+)(/[a-z]*)?$"
+            replacement: "${1}/ui/"
+            permanent: true
+
+        signup-redirect:
+          redirectregex:
+            regex: "^({{ $scheme }}://[^/]+)/signup"
+            replacement: "${1}/ui/#/signup"
+        #
+        # end of redirection rules valid up to 3.4 version
+        #
+
 {{- end }}
 
         sec-headers:

--- a/mender/templates/api-gateway-configmap.yaml
+++ b/mender/templates/api-gateway-configmap.yaml
@@ -245,9 +245,6 @@ data:
           entrypoints: {{ $scheme }}
           middlewares:
           - ratelimit
-          - ensure-ui-path
-          - signup-redirect
-          - ui-stripprefix
           - sec-headers
           - compression
           - json-error-responder1
@@ -460,26 +457,11 @@ data:
       # Middlewares
       #
       middlewares:
-        ui-stripprefix:
-          stripprefix:
-            prefixes: "/ui"
-
 {{- if .Values.api_gateway.env.SSL }}
         redirect-to-https:
           redirectscheme:
             scheme: https
 {{- end }}
-
-        ensure-ui-path:
-          redirectregex:
-            regex: "^({{ $scheme }}?://[^/]+)(/[a-z]*)?$"
-            replacement: "${1}/ui/"
-            permanent: true
-
-        signup-redirect:
-          redirectregex:
-            regex: "^({{ $scheme }}://[^/]+)/signup"
-            replacement: "${1}/ui/#/signup"
 
         sec-headers:
           headers:


### PR DESCRIPTION
Re-applied the commit `ad123cc9c926bd52842fa00217c0232cefa10498` to be compliant to the current `master` branch, but also applied some conditional logic to let it working with older Mender releases as well.