### PR TITLE
Revert "chore: added 3.6 upgrade tests"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,7 @@ test:helm_chart_install_sub_charts:
     - echo "INFO - cleaning up resources"
     - helm delete -n ${NAMESPACE} mender 
 
-test:helm_chart_upgrade_from3.6:
+test:helm_chart_upgrade_from3.3:
   tags:
     - mender-qa-worker-generic-light
   image: ${PIPELINE_TOOLBOX_IMAGE}
@@ -198,7 +198,7 @@ test:helm_chart_upgrade_from3.6:
   rules:
     - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
-    NAMESPACE: "mender-upgrade-test-3-6"
+    NAMESPACE: "mender-upgrade-test-3-3"
   before_script:
     - *set_eks_helmci_vars
     - |
@@ -215,7 +215,7 @@ test:helm_chart_upgrade_from3.6:
   script:
     - tests/ci-make-deps.sh
     - |
-      echo "INFO - installing mender tag ${MENDER_3_6_RELEASE_TAG:-mender-3.6}"
+      echo "INFO - installing mender 3.3"
       source ./tests/variables.sh
       helm upgrade -i mender \
         -f mender/values.yaml \
@@ -223,12 +223,12 @@ test:helm_chart_upgrade_from3.6:
         -f tests/values-helmci.yaml \
         --wait \
         --timeout=${HELM_UPGRADE_TIMEOUT:-15m} \
-        --set global.image.tag="${MENDER_3_6_RELEASE_TAG:-mender-3.6}" \
+        --set global.image.tag="mender-3.3" \
         --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} \
         --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
         --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" \
         --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" \
-        --namespace mender-upgrade-test-3-6 \
+        --namespace mender-upgrade-test-3-3 \
         mender/mender || exit 3;
     - bash tests/test-001-wait-for-pods-to-be-ready.sh
     - |
@@ -239,12 +239,74 @@ test:helm_chart_upgrade_from3.6:
         -f tests/values-helmci.yaml \
         --wait \
         --timeout=${HELM_UPGRADE_TIMEOUT:-15m} \
-        --set global.image.tag="${MENDER_3_6_RELEASE_TAG:-mender-3.6}" \
+        --set global.image.tag="mender-3.4" \
         --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} \
         --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
         --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" \
         --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" \
-        --namespace mender-upgrade-test-3-6 \
+        --namespace mender-upgrade-test-3-3 \
+        ./mender || exit 3;
+    - helm history mender
+    - make test
+
+test:helm_chart_upgrade_from3.4:
+  tags:
+    - mender-qa-worker-generic-light
+  image: ${PIPELINE_TOOLBOX_IMAGE}
+  stage: test
+  needs: ["build:setup_eks_cluster"]
+  dependencies:
+    - build:setup_eks_cluster
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+  variables:
+    NAMESPACE: "mender-upgrade-test-3-4"
+  before_script:
+    - *set_eks_helmci_vars
+    - |
+      eksctl utils write-kubeconfig --cluster=${EKS_CLUSTER_NAME}
+      kubectl create ns ${NAMESPACE}
+      kubectl config set-context --current --namespace=${NAMESPACE}
+    - |
+      echo "DEBUG - get kubectl nodes"
+      kubectl config current-context
+      kubectl get nodes
+    - |
+      echo "INFO - installing helm from scratch"
+      tests/ci-deps-k8s.sh
+  script:
+    - tests/ci-make-deps.sh
+    - |
+      echo "INFO - installing mender 3.4"
+      source ./tests/variables.sh
+      helm upgrade -i mender \
+        -f mender/values.yaml \
+        -f tests/keys.yaml \
+        -f tests/values-helmci.yaml \
+        --wait \
+        --timeout=${HELM_UPGRADE_TIMEOUT:-15m} \
+        --set global.image.tag="mender-3.4" \
+        --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} \
+        --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
+        --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" \
+        --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" \
+        --namespace mender-upgrade-test-3-4 \
+        mender/mender || exit 3;
+    - bash tests/test-001-wait-for-pods-to-be-ready.sh
+    - |
+      echo "INFO - installing this mender"
+      helm upgrade -i mender \
+        -f mender/values.yaml \
+        -f tests/keys.yaml \
+        -f tests/values-helmci.yaml \
+        --wait \
+        --timeout=${HELM_UPGRADE_TIMEOUT:-15m} \
+        --set global.image.tag="mender-3.4" \
+        --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} \
+        --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
+        --set global.s3.AWS_ACCESS_KEY_ID="${MINIO_accessKey}" \
+        --set global.s3.AWS_SECRET_ACCESS_KEY="${MINIO_secretKey}" \
+        --namespace mender-upgrade-test-3-4 \
         ./mender || exit 3;
     - helm history mender
     - make test


### PR DESCRIPTION
This reverts commit dd0e3510bcf518ea127c6d46b9eeff7a20174f8c.

Too early merge: it has to be merged with the 3.6 branch