### PR TITLE
Fix redis master address

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.0.2
+* Fix: always using the redis `master` address instead of the `headless` one, which leads to sporadic errors in writing when you have replicas in place.
+
 ## Version 5.0.1
 * Fix: workaround for a [known issue](https://github.com/bitnami/charts/issues/10843) with `bitnami/mongodb` when replicaset and auth are enabled
 

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.4.0"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.0.1
+version: 5.0.2
 keywords:
 - mender
 - iot

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Redis address
 */}}
 {{- define "redis_address" }}
   {{- if and .Values.redis.enabled ( not .Values.global.redis.URL ) }}
-    {{- printf "%s-headless:6379" ( include "common.names.fullname" .Subcharts.redis ) -}}
+    {{- printf "%s-master:6379" ( include "common.names.fullname" .Subcharts.redis ) -}}
   {{- else }}
     {{- printf .Values.global.redis.URL | quote }}
   {{- end }}


### PR DESCRIPTION
always using the redis `master` address instead of the `headless` one, which leads to sporadic errors in writing when you have replicas in place.