### PR TITLE
Align HM/Helm - Deployments and PDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ The following table lists the global, default, and other parameters supported by
 | `default.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `default.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `default.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `default.pdb.enabled` | PodDistruptionBudget enabled | `false` |
+| `default.pdb.minAvailable` | PodDistruptionBudget minAvailable | `1` |
 | `default.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `ingress.enabled` | Optional Mender Ingress | `false` |
 | `dbmigration.enable` | Helm Chart hook that trigger a DB Migration utility just before an Helm Chart install or upgrade  | `true` |
@@ -277,6 +279,8 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `api_gateway.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `api_gateway.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `api_gateway.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `api_gateway.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `api_gateway.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: deployments
@@ -325,6 +329,8 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `deployments.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `deployments.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `deployments.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `deployments.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `deployments.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: device-auth
@@ -376,6 +382,8 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `device_auth.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `device_auth.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `device_auth.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `device_auth.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `device_auth.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: gui
@@ -456,6 +464,8 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `inventory.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `inventory.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `inventory.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `inventory.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `inventory.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: reporting
@@ -530,6 +540,8 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `tenantadm.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `tenantadm.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `tenantadm.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `tenantadm.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `tenantadm.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 The default value for the rate limits are:
@@ -591,6 +603,8 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `useradm.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `useradm.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `useradm.pdb.enabled` | PodDistruptionBudget enabled | `nil` |
+| `useradm.pdb.minAvailable` | PodDistruptionBudget minAvailable | `nil` |
 | `useradm.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: workflows

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The following table lists the global, default, and other parameters supported by
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | `global.enterprise` | Enable the enterprise features | `true` |
 | `global.hosted` | Enabled Hosted Mender specific features | `false` |
+| `global.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the workwloads | `nil` |
 | `global.image.registry` | Global Docker image registry | `registry.mender.io` |
 | `global.image.username` | Global Docker image registry username | `nil` |
 | `global.image.password` | Global Docker image registry username | `password` |
@@ -276,6 +277,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `api_gateway.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `api_gateway.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `api_gateway.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: deployments
 
@@ -323,6 +325,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `deployments.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `deployments.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `deployments.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: device-auth
 
@@ -373,6 +376,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `device_auth.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `device_auth.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `device_auth.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: gui
 
@@ -409,6 +413,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `gui.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
 | `gui.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
+| `gui.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: inventory
 
@@ -451,6 +456,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `inventory.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `inventory.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `inventory.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: reporting
 
@@ -524,6 +530,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `tenantadm.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `tenantadm.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `tenantadm.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 The default value for the rate limits are:
 
@@ -584,6 +591,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `useradm.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `useradm.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `useradm.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: workflows
 
@@ -619,6 +627,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `workflows.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
 | `workflows.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
+| `workflows.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: create_artifact_worker
 
@@ -647,6 +656,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `create_artifact_worker.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
 | `create_artifact_worker.containerSecurityContext.runAsUser` | User ID for the container | `65534` |
+| `create_artifact_worker.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: auditlogs
 
@@ -689,6 +699,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `auditlogs.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `auditlogs.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `auditlogs.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: iot-manager
 
@@ -730,6 +741,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `iot_manager.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `iot_manager.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `iot_manager.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: deviceconnect
 
@@ -771,6 +783,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `deviceconnect.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `deviceconnect.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `deviceconnect.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: deviceconfig
 
@@ -812,6 +825,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `deviceconfig.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `deviceconfig.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `deviceconfig.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: devicemonitor
 
@@ -855,6 +869,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `devicemonitor.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `devicemonitor.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `devicemonitor.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: generate_delta_worker
 Please notice that this feature is still under active development and it is
@@ -879,6 +894,7 @@ The following table lists the parameters for the `generate-delta-worker` compone
 | `generate_delta_worker.resources.limits.memory` | Resources memory limit | `1024M` |
 | `generate_delta_worker.resources.requests.cpu` | Resources CPU request | `100m` |
 | `generate_delta_worker.resources.requests.memory` | Resources memory request | `128M` |
+| `generate_delta_worker.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 
 ### Parameters: redis
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ The following table lists the global, default, and other parameters supported by
 | `global.image.username` | Global Docker image registry username | `nil` |
 | `global.image.password` | Global Docker image registry username | `password` |
 | `global.image.tag` | Global Docker image registry tag | `mender-3.6.2` |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `global.mongodb.URL` | MongoDB URL | `mongodb://mongodb` |
 | `global.nats.URL` | NATS URL | `nats://nats:4222` |
 | `global.redis.username` | Optional Redis Username  | `nil` |
@@ -191,6 +190,7 @@ The following table lists the global, default, and other parameters supported by
 | `default.hpa.maxReplicas` | HorizontalPodAutoscaler maxReplicas | `nil` |
 | `default.hpa.metrics` | HorizontalPodAutoscaler metrics as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#metricspec-v2-autoscaling) | `nil` |
 | `default.hpa.behavior` | HorizontalPodAutoscaler behavior as defined in the [reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerbehavior-v2-autoscaling) | `nil` |
+| `default.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `ingress.enabled` | Optional Mender Ingress | `false` |
 | `dbmigration.enable` | Helm Chart hook that trigger a DB Migration utility just before an Helm Chart install or upgrade  | `true` |
 | `dbmigration.annotations` | Annotations for the DB Migration utility  | `nil` |
@@ -232,6 +232,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.image.repository` | Docker image repository | `traefik` |
 | `api_gateway.image.tag` | Docker image tag | `v2.5` |
 | `api_gateway.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `api_gateway.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `api_gateway.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `api_gateway.podAnnotations` | add custom pod annotations | `nil` |
 | `api_gateway.replicas` | Number of replicas | `1` |
@@ -288,6 +289,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.image.repository` | Docker image repository | `mendersoftware/deployments-enterprise` if `global.enterprise` is true, else `mendersoftware/deployments` |
 | `deployments.image.tag` | Docker image tag | `nil` |
 | `deployments.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deployments.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `deployments.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deployments.podAnnotations` | add custom pod annotations | `nil` |
 | `deployments.replicas` | Number of replicas | `1` |
@@ -334,6 +336,7 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.image.repository` | Docker image repository | `mendersoftware/deviceauth` |
 | `device_auth.image.tag` | Docker image tag | `nil` |
 | `device_auth.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `device_auth.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `device_auth.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `device_auth.podAnnotations` | add custom pod annotations | `nil` |
 | `device_auth.replicas` | Number of replicas | `1` |
@@ -382,6 +385,7 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.image.repository` | Docker image repository | `mendersoftware/gui` |
 | `gui.image.tag` | Docker image tag | `nil` |
 | `gui.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `gui.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `gui.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `gui.podAnnotations` | add custom pod annotations | `nil` |
 | `gui.replicas` | Number of replicas | `1` |
@@ -418,6 +422,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.image.repository` | Docker image repository | `mendersoftware/inventory-enterprise` if `global.enterprise` is true, else `mendersoftware/inventory` |
 | `inventory.image.tag` | Docker image tag | `nil` |
 | `inventory.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `inventory.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `inventory.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `inventory.podAnnotations` | add custom pod annotations | `nil` |
 | `inventory.replicas` | Number of replicas | `1` |
@@ -486,6 +491,7 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.image.repository` | Docker image repository | `mendersoftware/tenantadm` |
 | `tenantadm.image.tag` | Docker image tag | `nil` |
 | `tenantadm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `tenantadm.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `tenantadm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `tenantadm.podAnnotations` | add custom pod annotations | `nil` |
 | `tenantadm.replicas` | Number of replicas | `1` |
@@ -541,6 +547,7 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.image.repository` | Docker image repository | `mendersoftware/useradm-enterprise` if `global.enterprise` is true, else `mendersoftware/useradm` |
 | `useradm.image.tag` | Docker image tag | `nil` |
 | `useradm.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `useradm.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `useradm.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `useradm.podAnnotations` | add custom pod annotations | `nil` |
 | `useradm.replicas` | Number of replicas | `1` |
@@ -590,6 +597,7 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.image.repository` | Docker image repository | `mendersoftware/workflows-enterprise` if `global.enterprise` is true, else `mendersoftware/workflows` |
 | `workflows.image.tag` | Docker image tag | `nil` |
 | `workflows.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `workflows.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `workflows.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `workflows.podAnnotations` | add custom pod annotations | `nil` |
 | `workflows.replicas` | Number of replicas | `1` |
@@ -624,6 +632,7 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.image.repository` | Docker image repository | `mendersoftware/create-artifact-worker` |
 | `create_artifact_worker.image.tag` | Docker image tag | `nil` |
 | `create_artifact_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `create_artifact_worker.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `create_artifact_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `create_artifact_worker.podAnnotations` | add custom pod annotations | `nil` |
 | `create_artifact_worker.replicas` | Number of replicas | `1` |
@@ -651,6 +660,7 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.image.repository` | Docker image repository | `mendersoftware/auditlogs` |
 | `auditlogs.image.tag` | Docker image tag | `nil` |
 | `auditlogs.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `auditlogs.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `auditlogs.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `auditlogs.podAnnotations` | add custom pod annotations | `nil` |
 | `auditlogs.logRetentionSeconds` | Seconds before an audit event is evicted from the database | `2592000` |
@@ -692,6 +702,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.image.repository` | Docker image repository | `mendersoftware/iot-manager` |
 | `iot_manager.image.tag` | Docker image tag | `nil` |
 | `iot_manager.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `iot_manager.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `iot_manager.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `iot_manager.image.podAnnotations` | add custom pod annotations | `nil` |
 | `iot_manager.replicas` | Number of replicas | `1` |
@@ -732,6 +743,7 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.image.repository` | Docker image repository | `mendersoftware/deviceconnect` |
 | `deviceconnect.image.tag` | Docker image tag | `nil` |
 | `deviceconnect.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconnect.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `deviceconnect.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconnect.podAnnotations` | add custom pod annotations | `nil` |
 | `deviceconnect.replicas` | Number of replicas | `1` |
@@ -772,6 +784,7 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.image.repository` | Docker image repository | `mendersoftware/deviceconfig` |
 | `deviceconfig.image.tag` | Docker image tag | `nil` |
 | `deviceconfig.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `deviceconfig.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `deviceconfig.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `deviceconfig.podAnnotations` | add custom pod annotations | `nil` |
 | `deviceconfig.replicas` | Number of replicas | `1` |
@@ -812,6 +825,7 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.image.repository` | Docker image repository | `mendersoftware/devicemonitor` |
 | `devicemonitor.image.tag` | Docker image tag | `nil` |
 | `devicemonitor.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `devicemonotor.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `devicemonitor.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `devicemonitor.podAnnotations` | add custom pod annotations | `nil` |
 | `devicemonitor.replicas` | Number of replicas | `1` |
@@ -856,6 +870,7 @@ The following table lists the parameters for the `generate-delta-worker` compone
 | `generate_delta_worker.image.repository` | Docker image repository | `mendersoftware/generate-delta-worker` |
 | `generate_delta_worker.image.tag` | Docker image tag | `nil` |
 | `generate_delta_worker.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `generate_delta_worker.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `generate_delta_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `generate_delta_worker.podAnnotations` | add custom pod annotations | `nil` |
 | `generate_delta_worker.replicas` | Number of replicas | `1` |

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.rateLimit.burst` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `100` |
 | `api_gateway.rateLimit.period` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `1s` |
 | `api_gateway.rateLimit.sourceCriterion` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `{"ipStrategy": {"depth": 1}}` |
+| `api_gateway.extraArgs` | Optional list of additional args for the `api_gateway` container. | `null` |
 | `api_gateway.authRateLimit` | Optional rate limiting for the Auth module only. See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `null` |
 | `api_gateway.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `api_gateway.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added support to external Image Pull Secrets
 * Added support to extraArgs to the `api_gateway` service
 * Traefik updated to `v2.10.4`
+* You can now add pre-existing `priorityClassName` to the resources
 
 ## Version 5.2.4
 * Added HPA to the most critical services

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mender Helm chart
 
 ## Version 5.2.5
+* Added support to external Image Pull Secrets
 * Added support to extraArgs to the `api_gateway` service
 
 ## Version 5.2.4

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 5.2.5
 * Added support to external Image Pull Secrets
 * Added support to extraArgs to the `api_gateway` service
+* Traefik updated to `v2.10.4`
 
 ## Version 5.2.4
 * Added HPA to the most critical services

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.2.5
+* Added support to extraArgs to the `api_gateway` service
+
 ## Version 5.2.4
 * Added HPA to the most critical services
 * Reorganized `templates` directory with service subfolders

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support to extraArgs to the `api_gateway` service
 * Traefik updated to `v2.10.4`
 * You can now add pre-existing `priorityClassName` to the resources
+* Added PodDisruptionBudget resources to the most critical services
 
 ## Version 5.2.4
 * Added HPA to the most critical services

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -164,3 +164,24 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "mender.pdb" -}}
+{{- $pdb := dict }}
+{{- if .default.pdb }}
+{{- $_ := (mergeOverwrite $pdb .default.pdb) }}
+{{- end }}
+{{- if .override.pdb }}
+{{- $_ := (mergeOverwrite $pdb .override.pdb) }}
+{{- end }}
+{{- if $pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .name }}
+spec:
+  minAvailable: {{ $pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      run: {{ .name }}
+{{- end }}
+{{- end }}

--- a/mender/templates/_image-pull-secret.yaml
+++ b/mender/templates/_image-pull-secret.yaml
@@ -1,3 +1,3 @@
-{{- define "imagePullSecret" }}
+{{- define "mender.enterprisePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.global.image.registry (printf "%s:%s" .Values.global.image.username .Values.global.image.password | b64enc) | b64enc }}
 {{- end }}

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -152,5 +152,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.api_gateway.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
 {{- end }}
+{{- end }}
+
 {{- end }}

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -87,6 +87,9 @@ spec:
             - --providers.file.filename=/etc/traefik/config/traefik.yaml
             - --ping=true
             - --ping.manualrouting=true
+{{- if .Values.api_gateway.extraArgs }}
+{{- .Values.api_gateway.extraArgs | toYaml | nindent 12 }}
+{{- end }}
         resources:
 {{ toYaml .Values.api_gateway.resources | indent 10 }}
 

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -160,4 +160,9 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.api_gateway.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- end }}

--- a/mender/templates/api-gateway/pdb.yaml
+++ b/mender/templates/api-gateway/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.api_gateway.enabled }}
+{{- $servicename := "api-gateway" }}
+{{- $context := (dict "default" .Values.default "override" .Values.api_gateway "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/auditlogs/deployment.yaml
+++ b/mender/templates/auditlogs/deployment.yaml
@@ -106,6 +106,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.auditlogs.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.auditlogs.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/auditlogs/deployment.yaml
+++ b/mender/templates/auditlogs/deployment.yaml
@@ -98,6 +98,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.auditlogs.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.auditlogs.nodeSelector }}

--- a/mender/templates/create-artifact-worker/deployment.yaml
+++ b/mender/templates/create-artifact-worker/deployment.yaml
@@ -94,6 +94,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.create_artifact_worker.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.create_artifact_worker.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/create-artifact-worker/deployment.yaml
+++ b/mender/templates/create-artifact-worker/deployment.yaml
@@ -86,6 +86,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.create_artifact_worker.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.create_artifact_worker.nodeSelector }}

--- a/mender/templates/db-migration-job.yaml
+++ b/mender/templates/db-migration-job.yaml
@@ -257,7 +257,13 @@ spec:
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:
-      - name: docker-registry-prerelease
+      - name: docker-registry
+{{- else }}
+{{- $ips := .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.dbmigration.nodeSelector }}

--- a/mender/templates/deployments/cronjob.yaml
+++ b/mender/templates/deployments/cronjob.yaml
@@ -60,10 +60,18 @@ spec:
             securityContext: {{- omit .Values.deployments.containerSecurityContext "enabled" | toYaml | nindent 14 }}
             {{- end }}
           restartPolicy: Never
-          {{- if .Values.global.image.username }}
+
+{{- if .Values.global.image.username }}
           imagePullSecrets:
           - name: docker-registry
-          {{- end }}
+{{- else }}
+{{- $ips := coalesce .Values.deployments.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+          imagePullSecrets:
+{{ toYaml $ips | indent 10 }}
+{{- end }}
+{{- end }}
+
           {{- with .Values.deployments.nodeSelector }}
           nodeSelector: {{ toYaml . | nindent 8 }}
           {{- end }}

--- a/mender/templates/deployments/deployment.yaml
+++ b/mender/templates/deployments/deployment.yaml
@@ -134,6 +134,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.deployments.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.deployments.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/deployments/deployment.yaml
+++ b/mender/templates/deployments/deployment.yaml
@@ -126,6 +126,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.deployments.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.deployments.nodeSelector }}

--- a/mender/templates/deployments/pdb.yaml
+++ b/mender/templates/deployments/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.deployments.enabled }}
+{{- $servicename := "deployments" }}
+{{- $context := (dict "default" .Values.default "override" .Values.deployments "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/device-auth/cronjob.yaml
+++ b/mender/templates/device-auth/cronjob.yaml
@@ -40,8 +40,16 @@ spec:
                 name: mongodb-common
 
           restartPolicy: Never
+
 {{- if .Values.global.image.username }}
           imagePullSecrets:
           - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.device_auth.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+          imagePullSecrets:
+{{ toYaml $ips | indent 10 }}
 {{- end }}
+{{- end }}
+
 {{- end }}

--- a/mender/templates/device-auth/deployment.yaml
+++ b/mender/templates/device-auth/deployment.yaml
@@ -157,4 +157,9 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.device_auth.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- end }}

--- a/mender/templates/device-auth/deployment.yaml
+++ b/mender/templates/device-auth/deployment.yaml
@@ -149,5 +149,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.device_auth.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
 {{- end }}
+{{- end }}
+
 {{- end }}

--- a/mender/templates/device-auth/pdb.yaml
+++ b/mender/templates/device-auth/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.device_auth.enabled }}
+{{- $servicename := "device-auth" }}
+{{- $context := (dict "default" .Values.default "override" .Values.device_auth "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/deviceconfig/deployment.yaml
+++ b/mender/templates/deviceconfig/deployment.yaml
@@ -114,6 +114,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.deviceconfig.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.deviceconfig.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/deviceconfig/deployment.yaml
+++ b/mender/templates/deviceconfig/deployment.yaml
@@ -106,6 +106,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.deviceconfig.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.deviceconfig.nodeSelector }}

--- a/mender/templates/deviceconnect/deployment.yaml
+++ b/mender/templates/deviceconnect/deployment.yaml
@@ -116,6 +116,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.deviceconnect.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.deviceconnect.nodeSelector }}

--- a/mender/templates/deviceconnect/deployment.yaml
+++ b/mender/templates/deviceconnect/deployment.yaml
@@ -124,6 +124,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.deviceconnect.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.deviceconnect.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/devicemonitor/deployment.yaml
+++ b/mender/templates/devicemonitor/deployment.yaml
@@ -104,7 +104,14 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.devicemonitor.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
 {{- end }}
+{{- end }}
+
 
 {{- with .Values.devicemonitor.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/mender/templates/devicemonitor/deployment.yaml
+++ b/mender/templates/devicemonitor/deployment.yaml
@@ -113,6 +113,11 @@ spec:
 {{- end }}
 
 
+{{- $pcn := coalesce .Values.devicemonitor.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.devicemonitor.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/generate-delta-worker/deployment.yaml
+++ b/mender/templates/generate-delta-worker/deployment.yaml
@@ -88,6 +88,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.generate_delta_worker.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.generate_delta_worker.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/generate-delta-worker/deployment.yaml
+++ b/mender/templates/generate-delta-worker/deployment.yaml
@@ -80,6 +80,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.generate_delta_worker.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.generate_delta_worker.nodeSelector }}

--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -106,6 +106,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.gui.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.gui.nodeSelector }}

--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -114,6 +114,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.gui.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.gui.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/inventory/deployment.yaml
+++ b/mender/templates/inventory/deployment.yaml
@@ -111,7 +111,13 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.inventory.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.inventory.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}
+
 {{- end }}

--- a/mender/templates/inventory/deployment.yaml
+++ b/mender/templates/inventory/deployment.yaml
@@ -103,6 +103,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.inventory.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.inventory.nodeSelector }}

--- a/mender/templates/inventory/pdb.yaml
+++ b/mender/templates/inventory/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.inventory.enabled }}
+{{- $servicename := "inventory" }}
+{{- $context := (dict "default" .Values.default "override" .Values.inventory "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/iot-manager/deployment.yaml
+++ b/mender/templates/iot-manager/deployment.yaml
@@ -96,6 +96,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.iot_manager.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.iot_manager.nodeSelector }}

--- a/mender/templates/iot-manager/deployment.yaml
+++ b/mender/templates/iot-manager/deployment.yaml
@@ -104,6 +104,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.iot_manager.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.iot_manager.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/secrets/secret-docker-registry-prerelease.yaml
+++ b/mender/templates/secrets/secret-docker-registry-prerelease.yaml
@@ -17,5 +17,5 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ template "imagePullSecret" . }}
+  .dockerconfigjson: {{ template "mender.enterprisePullSecret" . }}
 {{- end }}

--- a/mender/templates/secrets/secret-docker-registry.yaml
+++ b/mender/templates/secrets/secret-docker-registry.yaml
@@ -13,5 +13,5 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ template "imagePullSecret" . }}
+  .dockerconfigjson: {{ template "mender.enterprisePullSecret" . }}
 {{- end }}

--- a/mender/templates/tenantadm/deployment.yaml
+++ b/mender/templates/tenantadm/deployment.yaml
@@ -127,4 +127,9 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.tenantadm.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- end }}

--- a/mender/templates/tenantadm/deployment.yaml
+++ b/mender/templates/tenantadm/deployment.yaml
@@ -119,5 +119,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.tenantadm.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
 {{- end }}
+{{- end }}
+
 {{- end }}

--- a/mender/templates/tenantadm/pdb.yaml
+++ b/mender/templates/tenantadm/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.tenantadm.enabled }}
+{{- $servicename := "tenantadm" }}
+{{- $context := (dict "default" .Values.default "override" .Values.tenantadm "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/useradm/deployment.yaml
+++ b/mender/templates/useradm/deployment.yaml
@@ -159,4 +159,10 @@ spec:
 {{ toYaml $ips | indent 6 }}
 {{- end }}
 {{- end }}
+
+{{- $pcn := coalesce .Values.useradm.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- end }}

--- a/mender/templates/useradm/deployment.yaml
+++ b/mender/templates/useradm/deployment.yaml
@@ -152,5 +152,11 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.useradm.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/mender/templates/useradm/pdb.yaml
+++ b/mender/templates/useradm/pdb.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.useradm.enabled }}
+{{- $servicename := "useradm" }}
+{{- $context := (dict "default" .Values.default "override" .Values.useradm "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.pdb" $context }}
+{{- end }}

--- a/mender/templates/workflows/deployment-server.yaml
+++ b/mender/templates/workflows/deployment-server.yaml
@@ -101,6 +101,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.workflows.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.workflows.nodeSelector }}

--- a/mender/templates/workflows/deployment-server.yaml
+++ b/mender/templates/workflows/deployment-server.yaml
@@ -109,6 +109,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.workflows.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.workflows.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/workflows/deployment-worker.yaml
+++ b/mender/templates/workflows/deployment-worker.yaml
@@ -108,6 +108,11 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- $pcn := coalesce .Values.workflows.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end -}}
+
 {{- with .Values.workflows.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/mender/templates/workflows/deployment-worker.yaml
+++ b/mender/templates/workflows/deployment-worker.yaml
@@ -100,6 +100,12 @@ spec:
 {{- if .Values.global.image.username }}
       imagePullSecrets:
       - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.workflows.imagePullSecrets .Values.default.imagePullSecrets  }}
+{{- if $ips }}
+      imagePullSecrets:
+{{ toYaml $ips | indent 6 }}
+{{- end }}
 {{- end }}
 
 {{- with .Values.workflows.nodeSelector }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -2,11 +2,15 @@ global:
   enterprise: true
   hosted: false
   auditlogs: true
+  priorityClassName: ""
+
+
   image:
     registry: registry.mender.io
     username: null
     password: null
     tag: mender-3.6.2
+
   mongodb:
     URL: mongodb://mongodb
   nats:
@@ -155,6 +159,7 @@ api_gateway:
     repository: traefik
     tag: v2.10
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   replicas: 1
   resources:
     limits:
@@ -223,6 +228,7 @@ deployments:
     registry: ""
     repository: ""
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-deployments
@@ -259,6 +265,7 @@ device_auth:
     registry: ""
     repository: ""
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-device-auth
@@ -306,6 +313,7 @@ generate_delta_worker:
     repository: mendersoftware/generate-delta-worker
     tag: mender-3.5.0
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
 
 gui:
@@ -324,6 +332,7 @@ gui:
     registry: docker.io
     repository: mendersoftware/gui
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-gui
@@ -358,6 +367,7 @@ inventory:
     registry: ""
     repository: ""
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-inventory
@@ -392,6 +402,7 @@ tenantadm:
     registry: registry.mender.io
     repository: mendersoftware/tenantadm
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-tenantadm
@@ -431,6 +442,7 @@ useradm:
     registry: ""
     repository: ""
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-useradm
@@ -474,6 +486,7 @@ workflows:
     registry: ""
     repository: ""
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-workflows-server
@@ -506,6 +519,7 @@ create_artifact_worker:
     registry: docker.io
     repository: mendersoftware/create-artifact-worker
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   podSecurityContext:
     enabled: false
@@ -535,6 +549,7 @@ auditlogs:
     registry: registry.mender.io
     repository: mendersoftware/auditlogs
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-auditlogs
@@ -568,6 +583,7 @@ iot_manager:
     registry: docker.io
     repository: mendersoftware/iot-manager
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-iot-manager
@@ -601,6 +617,7 @@ deviceconnect:
     registry: docker.io
     repository: mendersoftware/deviceconnect
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-deviceconnect
@@ -634,6 +651,7 @@ deviceconfig:
     registry: docker.io
     repository: mendersoftware/deviceconfig
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-deviceconfig
@@ -667,6 +685,7 @@ devicemonitor:
     registry: registry.mender.io
     repository: mendersoftware/devicemonitor
     imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
   nodeSelector: {}
   service:
     name: mender-devicemonitor

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -189,6 +189,7 @@ api_gateway:
     sourceCriterion:
       ipStrategy:
         depth: 1
+  extraArgs: []
   authRateLimit: null
   podSecurityContext:
     enabled: false

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -3,8 +3,6 @@ global:
   hosted: false
   auditlogs: true
   priorityClassName: ""
-
-
   image:
     registry: registry.mender.io
     username: null
@@ -205,6 +203,7 @@ api_gateway:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 deployments:
   enabled: true
@@ -247,6 +246,7 @@ deployments:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 device_auth:
   enabled: true
@@ -291,6 +291,7 @@ device_auth:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 # Generate Delta Worker feature
 # Experimental feature, still in beta
@@ -315,6 +316,7 @@ generate_delta_worker:
     imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   nodeSelector: {}
+  priorityClassName: ""
 
 gui:
   enabled: true
@@ -349,6 +351,7 @@ gui:
     enabled: false
     allowPrivilegeEscalation: false
     runAsUser: 65534
+  priorityClassName: ""
 
 inventory:
   enabled: true
@@ -385,6 +388,7 @@ inventory:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 tenantadm:
   enabled: true
@@ -424,6 +428,7 @@ tenantadm:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 useradm:
   enabled: true
@@ -468,6 +473,7 @@ useradm:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 workflows:
   enabled: true
@@ -501,6 +507,7 @@ workflows:
     enabled: false
     allowPrivilegeEscalation: false
     runAsUser: 65534
+  priorityClassName: ""
 
 create_artifact_worker:
   enabled: true
@@ -529,6 +536,7 @@ create_artifact_worker:
     enabled: false
     allowPrivilegeEscalation: false
     runAsUser: 65534
+  priorityClassName: ""
 
 auditlogs:
   enabled: true
@@ -565,6 +573,7 @@ auditlogs:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 iot_manager:
   enabled: true
@@ -599,6 +608,7 @@ iot_manager:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 deviceconnect:
   enabled: true
@@ -633,6 +643,7 @@ deviceconnect:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 deviceconfig:
   enabled: true
@@ -667,6 +678,7 @@ deviceconfig:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 devicemonitor:
   enabled: true
@@ -701,6 +713,7 @@ devicemonitor:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  priorityClassName: ""
 
 # Redis as a subchart
 # Using a bitnami sub-chart by default = test usage only

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -157,7 +157,7 @@ api_gateway:
   image:
     registry: docker.io
     repository: traefik
-    tag: v2.10
+    tag: v2.10.4
     imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   replicas: 1

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -61,6 +61,11 @@ default:
     #metrics: {}
     #behavior: {}
 
+  # PodDisruptionBudget default resources
+  pdb:
+    enabled: false
+    minAvailable: 1
+
 # Enabling this will publically expose your Mender instance.
 ingress:
   enabled: false
@@ -203,6 +208,7 @@ api_gateway:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 deployments:
@@ -246,6 +252,7 @@ deployments:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 device_auth:
@@ -291,6 +298,7 @@ device_auth:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 # Generate Delta Worker feature
@@ -388,6 +396,7 @@ inventory:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 tenantadm:
@@ -428,6 +437,7 @@ tenantadm:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 useradm:
@@ -473,6 +483,7 @@ useradm:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 workflows:
@@ -573,6 +584,7 @@ auditlogs:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 iot_manager:
@@ -608,6 +620,7 @@ iot_manager:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 deviceconnect:
@@ -643,6 +656,7 @@ deviceconnect:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 deviceconfig:
@@ -678,6 +692,7 @@ deviceconfig:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 devicemonitor:
@@ -713,6 +728,7 @@ devicemonitor:
     allowPrivilegeEscalation: false
     runAsUser: 65534
   hpa: {}
+  pdb: {}
   priorityClassName: ""
 
 # Redis as a subchart


### PR DESCRIPTION
Focusing on the `kind: Deployments` drift. Here's the changes:
* Added support to external Image Pull Secrets, global and per-service
* Added support to extraArgs to the `api_gateway` service
* Traefik updated to `v2.9.6`
* You can now add pre-existing `priorityClassName` to the resources
* Added PodDisruptionBudget resources