### PR TITLE
Build step is missing when publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,7 @@ build:
   rules:
     - if: '$RUN_PLAYGROUND == "true"'
       when: never
+    - when: on_success
   before_script:
     - apt-get update -y
     - apt-get install -y curl make


### PR DESCRIPTION
This missing step prevents the publish pipeline to succeed. With this PR we want to have it back.