### PR TITLE
Option to use existing secrets for certificates

### DIFF
--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -143,7 +143,13 @@ spec:
 {{- if .Values.api_gateway.env.SSL }}
       - name: certs
         secret:
+          {{- with .Values.api_gateway.certs }}
+          {{- if .existingSecret }}
+          secretName: {{ .existingSecret }}
+          {{- else }}
           secretName: api-gateway
+          {{- end }}
+          {{- end }}
 {{- end }}
 
 {{- if .Values.global.image.username }}

--- a/mender/templates/api-gateway/secret.yaml
+++ b/mender/templates/api-gateway/secret.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.api_gateway.enabled .Values.api_gateway.env.SSL }}
+{{- if not .Values.api_gateway.certs.existingSecret }}
 {{- $dummy := required "Valid certificates for api_gateway are required!" .Values.api_gateway.certs -}}
 apiVersion: v1
 kind: Secret
@@ -19,4 +20,5 @@ data:
   {{- if .Values.api_gateway.certs.key }}
   private.key: {{ .Values.api_gateway.certs.key | b64enc}}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/mender/templates/device-auth/deployment.yaml
+++ b/mender/templates/device-auth/deployment.yaml
@@ -144,7 +144,13 @@ spec:
       volumes:
       - name: rsa
         secret:
+          {{- with .Values.device_auth.certs }}
+          {{- if .existingSecret }}
+          secretName: {{ .existingSecret }}
+          {{- else }}
           secretName: rsa-device-auth
+          {{- end }}
+          {{- end }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/device-auth/secret.yaml
+++ b/mender/templates/device-auth/secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.device_auth.enabled }}
+{{- if not .Values.device_auth.certs.existingSecret }}
 {{- $dummy := required "Valid private key for device_auth is required!" .Values.device_auth.certs -}}
 apiVersion: v1
 kind: Secret
@@ -14,4 +15,5 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 data:
   private.pem: {{ .Values.device_auth.certs.key | b64enc }}
+{{- end }}
 {{- end }}

--- a/mender/templates/tenantadm/deployment.yaml
+++ b/mender/templates/tenantadm/deployment.yaml
@@ -114,7 +114,13 @@ spec:
       volumes:
       - name: rsa
         secret:
+          {{- with .Values.tenantadm.certs }}
+          {{- if .existingSecret }}
+          secretName: {{ .existingSecret }}
+          {{- else }}
           secretName: rsa-tenantadm
+          {{- end }}
+          {{- end }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/tenantadm/secret.yaml
+++ b/mender/templates/tenantadm/secret.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) }}
+{{- if not .Values.tenantadm.certs.existingSecret }}
 {{- $dummy := required "Valid private key for tenantadm is required!" .Values.tenantadm.certs -}}
 apiVersion: v1
 kind: Secret
@@ -14,4 +15,5 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 data:
   private.pem: {{ .Values.tenantadm.certs.key | b64enc }}
+{{- end }}
 {{- end }}

--- a/mender/templates/useradm/deployment.yaml
+++ b/mender/templates/useradm/deployment.yaml
@@ -147,7 +147,13 @@ spec:
       volumes:
       - name: rsa
         secret:
+          {{- with .Values.useradm.certs }}
+          {{- if .existingSecret }}
+          secretName: {{ .existingSecret }}
+          {{- else }}
           secretName: rsa-useradm
+          {{- end }}
+          {{- end }}
 
 {{- if .Values.global.image.username }}
       imagePullSecrets:

--- a/mender/templates/useradm/secret.yaml
+++ b/mender/templates/useradm/secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.useradm.enabled }}
+{{- if not .Values.useradm.certs.existingSecret }}
 {{- $dummy := required "Valid private key for useradm is required!" .Values.useradm.certs -}}
 apiVersion: v1
 kind: Secret
@@ -14,4 +15,5 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}"
 data:
   private.pem: {{ .Values.useradm.certs.key | b64enc }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The current way of creating the secrets for certs via the Helm charts does not  work well with external secret management tools like Vault and Vault webhook. 

This PR adds an existingSecret parameter to all `certs` to not have the Helm chart render the secrets and instead letting the external tools manage them.