### PR TITLE
New helm release: 5.2.5 from master

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -7,6 +7,7 @@
 * You can now add pre-existing `priorityClassName` to the resources
 * Added PodDisruptionBudget resources to the most critical services
 * Added option to use existing secrets for certificates (thanks @bdomars)
+* Allow to use external secrets for NATS, MongoDB, and S3 (thanks @benjamin-texier)
 
 ## Version 5.2.4
 * Added HPA to the most critical services

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.6.2"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.2.4
+version: 5.2.5
 keywords:
 - mender
 - iot


### PR DESCRIPTION
Changes from 5.2.4:

## Version 5.2.5
* Added support to external Image Pull Secrets
* Added support to extraArgs to the `api_gateway` service
* Traefik updated to `v2.10.4`
* You can now add pre-existing `priorityClassName` to the resources
* Added PodDisruptionBudget resources to the most critical services
* Added option to use existing secrets for certificates (thanks @bdomars)
* Allow to use external secrets for NATS, MongoDB, and S3 (thanks @benjamin-texier)