### PR TITLE
fix: indent cronjob annotations correctly

### DIFF
--- a/mender/templates/deployments/cronjob.yaml
+++ b/mender/templates/deployments/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
         metadata:
           {{- with .Values.deployments.podAnnotations }}
           annotations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           labels:
             app.kubernetes.io/name: {{ include "mender.fullname" . }}-deployments-storage-daemon


### PR DESCRIPTION
Hello!

I noticed that the helm chart cannot render the yaml correctly if you add pod annotations to the deployments section. I tracked this down to be a simple indentation miss. 