### PR TITLE
feat: Add serviceAccount options to Helm Chart

### DIFF
--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -185,3 +185,15 @@ spec:
       run: {{ .name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "mender.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mender.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -58,6 +58,7 @@ spec:
 {{- if .Values.api_gateway.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.api_gateway.podSecurityContext "enabled" | toYaml | nindent 8 }}
 {{- end }}
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
 
       containers:
       - name: api-gateway

--- a/mender/templates/auditlogs/deployment.yaml
+++ b/mender/templates/auditlogs/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: auditlogs
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/deployments/cronjob.yaml
+++ b/mender/templates/deployments/cronjob.yaml
@@ -22,6 +22,7 @@ spec:
             app.kubernetes.io/name: {{ include "mender.fullname" . }}-deployments-storage-daemon
 
         spec:
+          serviceAccountName: {{ include "mender.serviceAccountName" . }}
           {{- with $merged.affinity }}
           affinity: {{ tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/mender/templates/deployments/deployment.yaml
+++ b/mender/templates/deployments/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: deployments
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/device-auth/cronjob.yaml
+++ b/mender/templates/device-auth/cronjob.yaml
@@ -23,6 +23,7 @@ spec:
             app.kubernetes.io/name: {{ include "mender.fullname" . }}-device-auth-license-count
 
         spec:
+          serviceAccountName: {{ include "mender.serviceAccountName" . }}
           {{- with $merged.affinity }}
           affinity: {{ tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/mender/templates/device-auth/deployment.yaml
+++ b/mender/templates/device-auth/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: device-auth
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/deviceconfig/deployment.yaml
+++ b/mender/templates/deviceconfig/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: deviceconfig
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/deviceconnect/deployment.yaml
+++ b/mender/templates/deviceconnect/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: deviceconnect
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/devicemonitor/deployment.yaml
+++ b/mender/templates/devicemonitor/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: devicemonitor
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/generate-delta-worker/deployment.yaml
+++ b/mender/templates/generate-delta-worker/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: workflows
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: gui
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/inventory/deployment.yaml
+++ b/mender/templates/inventory/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: inventory
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/iot-manager/deployment.yaml
+++ b/mender/templates/iot-manager/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: iot-manager
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/serviceaccount.yaml
+++ b/mender/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $ }}
+  {{- end }}
+  name: {{ include "mender.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/mender/templates/tenantadm/deployment.yaml
+++ b/mender/templates/tenantadm/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         app.kubernetes.io/name: {{ include "mender.fullname" . }}-tenantadm
         app.kubernetes.io/component: tenantadm
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/useradm/deployment.yaml
+++ b/mender/templates/useradm/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: useradm
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/workflows/deployment-server.yaml
+++ b/mender/templates/workflows/deployment-server.yaml
@@ -39,6 +39,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: workflows
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/templates/workflows/deployment-worker.yaml
+++ b/mender/templates/workflows/deployment-worker.yaml
@@ -39,6 +39,7 @@ spec:
         {{- include "mender.labels" . | nindent 8 }}
         app.kubernetes.io/component: workflows
     spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
       {{- with $merged.affinity }}
       affinity: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -69,6 +69,12 @@ default:
     enabled: false
     minAvailable: 1
 
+serviceAccount:
+  create: false
+  # labels: {}
+  # annotations: {}
+  # name: "mender"
+
 # Enabling this will publically expose your Mender instance.
 ingress:
   enabled: false


### PR DESCRIPTION
Adds an option to use a named service account or create a named service account to use for all mender services.

Tried keeping this similar to how other Charts do it.

This is a nice to have if you use kubernetes service accounts to identify the pods in services like Vault for secret injection.