### PR TITLE
chore: fix R2 setup test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -629,7 +629,6 @@ test:helm_chart_install_with_r2:
         --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
         --set global.s3.AWS_URI="${R2_TEST_AWS_URI}" \
         --set global.s3.AWS_BUCKET="${R2_TEST_BUCKET}" \
-        --set global.s3.AWS_FORCE_PATH_STYLE="true" \
         --set global.s3.AWS_ACCESS_KEY_ID="${R2_TEST_ACCESS_KEY_ID}" \
         --set global.s3.AWS_SECRET_ACCESS_KEY="${R2_TEST_SECRET_ACCESS_KEY}" \
         --namespace "${NAMESPACE}" \


### PR DESCRIPTION
Ticket: MC-7138

`--set global.s3.AWS_FORCE_PATH_STYLE="true"` is rendered as a bool, not string. It would have been:
`--set global.s3.AWS_FORCE_PATH_STYLE=\"true\"`. Anyway, the default value in the `mender/values.yaml` is already `"true"`, so we can omit this setting here.