### PR TITLE
Helm minio deprecation

### DIFF
--- a/tests/ci-deps-k8s.sh
+++ b/tests/ci-deps-k8s.sh
@@ -21,9 +21,6 @@ set -e
 log "add helm repo: stable"
 helm repo add stable https://charts.helm.sh/stable
 
-log "add helm repo: minio"
-helm repo add minio https://helm.min.io/
-
 log "add helm repo: mongodb"
 helm repo add bitnami https://charts.bitnami.com/bitnami
 

--- a/tests/ci-make-deps.sh
+++ b/tests/ci-make-deps.sh
@@ -21,11 +21,8 @@ set -e
 local_minio_only=${1:-"false"}
 
 log "deploying dependencies: minio"
-helm install mender-minio minio/minio \
-    --version 8.0.10 \
-    --set "image.tag=RELEASE.2021-02-14T04-01-33Z" \
-    --set resources.requests.memory=100Mi \
-    --set accessKey=${MINIO_accessKey},secretKey=${MINIO_secretKey},persistence.enabled=false
+kubectl create secret generic mender-minio --from-literal=root-user=${MINIO_accessKey} --from-literal=root-password=${MINIO_secretKey}
+kubectl apply -f tests/minio-standalone/minio.yaml
 
 if [[ "$local_minio_only" == "true" ]]; then
   log "not deploying mongodb"

--- a/tests/minio-standalone/minio.yaml
+++ b/tests/minio-standalone/minio.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mender-minio
+  labels:
+    app.kubernetes.io/instance: mender-minio
+    app.kubernetes.io/name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: mender-minio
+    app.kubernetes.io/name: minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mender-minio
+  labels:
+    app.kubernetes.io/instance: mender-minio
+    app.kubernetes.io/name: minio
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: mender-minio
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: mender-minio
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+      - name: minio
+        image: minio/minio:RELEASE.2021-02-14T04-01-33Z
+        args:
+        - server
+        - /storage
+        env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: mender-minio
+              key: root-user
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mender-minio
+              key: root-password
+        - name: MINIO_SCHEME
+          value: "http"
+        - name: MINIO_FORCE_NEW_KEYS
+          value: "no"
+        - name: MINIO_BROWSER
+          value: "off"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000


### PR DESCRIPTION
as a drop-in replacement of the deprecated
https://helm.min.io/, still including the old-licensed image

Ticket: QA-641