### PR TITLE
Malformed auth header when authRateLimit is set

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## 5.5.4
+* fix malformed Authorization header when authRateLimit is set
+
 ## 5.5.3
 * create artifact worker: change container name from workflows
 * generate delta worker: change container name from workflows

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.2"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.5.3
+version: 5.5.4
 keywords:
   - mender
   - iot

--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -405,7 +405,7 @@ data:
           entrypoints: {{ $scheme }}
           middlewares:
 {{- if .Values.api_gateway.authRateLimit }}
-          - authRatelimit
+          - authRateLimit
 {{- else }}
           - ratelimit
 {{- end }}


### PR DESCRIPTION
When the api_gateway.authRateLimit is set, a malformed authorization header error is displayed at login. This fix solves the issue

Ticket: MC-6856