### PR TITLE
Fixes and alignements to saas

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.certs.key` | Private key in PEM format | `nil` |
 | `api_gateway.certs.existingSecret` | Preexisting secret containing the Cert (key `cert.crt`) and the Key (key `private.key`) | `nil` |
 | `api_gateway.updateStrategy` | The strategy to use to update existing pods | `nil` |
+| `api_gateway.accesslogs` | Traefik Access Logs, enabled by default | `true` |
 
 ### Parameters: deployments
 

--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.httpPort` | Port for the HTTP listener in the container | `9080` |
 | `api_gateway.httpsPort` | Port for the HTTPS listener in the container | `9443` |
 | `api_gateway.resources.limits.cpu` | Resources CPU limit | `600m` |
-| `api_gateway.resources.limits.memory` | Resources memory limit | `1G` |
+| `api_gateway.resources.limits.memory` | Resources memory limit | `1Gi` |
 | `api_gateway.resources.requests.cpu` | Resources CPU request | `600m` |
-| `api_gateway.resources.requests.memory` | Resources memory request | `512M` |
+| `api_gateway.resources.requests.memory` | Resources memory request | `512Mi` |
 | `api_gateway.service.name` | Name of the service | `mender-api-gateway` |
 | `api_gateway.service.annotations` | Annotations map for the service | `{}` |
 | `api_gateway.service.type` | Service type | `ClusterIP` |
@@ -362,9 +362,9 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.directUpload.skipVerify`  | Skip verification of artifact uploaded through direct upload. Only advised if you verified the direct upload through other means. | `false` |
 | `deployments.daemonSchedule` | Cron schedule for running the storage daemon | `"15 * * * *"` |
 | `deployments.resources.limits.cpu` | Resources CPU limit | `300m` |
-| `deployments.resources.limits.memory` | Resources memory limit | `128M` |
+| `deployments.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `deployments.resources.requests.cpu` | Resources CPU request | `300m` |
-| `deployments.resources.requests.memory` | Resources memory request | `64M` |
+| `deployments.resources.requests.memory` | Resources memory request | `64Mi` |
 | `deployments.service.name` | Name of the service | `mender-deployments` |
 | `deployments.service.annotations` | Annotations map for the service | `{}` |
 | `deployments.service.type` | Service type | `ClusterIP` |
@@ -412,9 +412,9 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.replicas` | Number of replicas | `1` |
 | `device_auth.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `device_auth.resources.limits.cpu` | Resources CPU limit | `350m` |
-| `device_auth.resources.limits.memory` | Resources memory limit | `128M` |
+| `device_auth.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `device_auth.resources.requests.cpu` | Resources CPU request | `350m` |
-| `device_auth.resources.requests.memory` | Resources memory request | `128M` |
+| `device_auth.resources.requests.memory` | Resources memory request | `128Mi` |
 | `device_auth.service.name` | Name of the service | `mender-device-auth` |
 | `device_auth.service.annotations` | Annotations map for the service | `{}` |
 | `device_auth.service.type` | Service type | `ClusterIP` |
@@ -471,9 +471,9 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.replicas` | Number of replicas | `1` |
 | `gui.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `gui.resources.limits.cpu` | Resources CPU limit | `20m` |
-| `gui.resources.limits.memory` | Resources memory limit | `64M` |
+| `gui.resources.limits.memory` | Resources memory limit | `64Mi` |
 | `gui.resources.requests.cpu` | Resources CPU request | `5m` |
-| `gui.resources.requests.memory` | Resources memory request | `16M` |
+| `gui.resources.requests.memory` | Resources memory request | `16Mi` |
 | `gui.service.name` | Name of the service | `mender-gui` |
 | `gui.service.annotations` | Annotations map for the service | `{}` |
 | `gui.service.type` | Service type | `ClusterIP` |
@@ -510,9 +510,9 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.replicas` | Number of replicas | `1` |
 | `inventory.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `inventory.resources.limits.cpu` | Resources CPU limit | `300m` |
-| `inventory.resources.limits.memory` | Resources memory limit | `128M` |
+| `inventory.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `inventory.resources.requests.cpu` | Resources CPU request | `300m` |
-| `inventory.resources.requests.memory` | Resources memory request | `128M` |
+| `inventory.resources.requests.memory` | Resources memory request | `128Mi` |
 | `inventory.service.name` | Name of the service | `mender-inventory` |
 | `inventory.service.annotations` | Annotations map for the service | `{}` |
 | `inventory.service.type` | Service type | `ClusterIP` |
@@ -559,9 +559,9 @@ The following table lists the parameters for the `reporting` component and their
 | `reporting.replicas` | Number of replicas | `1` |
 | `reporting.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `reporting.resources.limits.cpu` | Resources CPU limit | `50m` |
-| `reporting.resources.limits.memory` | Resources memory limit | `128M` |
+| `reporting.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `reporting.resources.requests.cpu` | Resources CPU request | `50m` |
-| `reporting.resources.requests.memory` | Resources memory request | `128M` |
+| `reporting.resources.requests.memory` | Resources memory request | `128Mi` |
 | `reporting.service.name` | Name of the service | `mender-reporting` |
 | `reporting.service.annotations` | Annotations map for the service | `{}` |
 | `reporting.service.type` | Service type | `ClusterIP` |
@@ -587,9 +587,9 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.replicas` | Number of replicas | `1` |
 | `tenantadm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `tenantadm.resources.limits.cpu` | Resources CPU limit | `150m` |
-| `tenantadm.resources.limits.memory` | Resources memory limit | `128M` |
+| `tenantadm.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `tenantadm.resources.requests.cpu` | Resources CPU request | `150m` |
-| `tenantadm.resources.requests.memory` | Resources memory request | `64M` |
+| `tenantadm.resources.requests.memory` | Resources memory request | `64Mi` |
 | `tenantadm.service.name` | Name of the service | `mender-tenantadm` |
 | `tenantadm.service.annotations` | Annotations map for the service | `{}` |
 | `tenantadm.service.type` | Service type | `ClusterIP` |
@@ -653,9 +653,9 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.replicas` | Number of replicas | `1` |
 | `useradm.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `useradm.resources.limits.cpu` | Resources CPU limit | `150m` |
-| `useradm.resources.limits.memory` | Resources memory limit | `128M` |
+| `useradm.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `useradm.resources.requests.cpu` | Resources CPU request | `150m` |
-| `useradm.resources.requests.memory` | Resources memory request | `64M` |
+| `useradm.resources.requests.memory` | Resources memory request | `64Mi` |
 | `useradm.service.name` | Name of the service | `mender-useradm` |
 | `useradm.service.annotations` | Annotations map for the service | `{}` |
 | `useradm.service.type` | Service type | `ClusterIP` |
@@ -713,9 +713,9 @@ The following table lists the parameters for the `workflows-server` component an
 | `workflows.replicas` | Number of replicas | `1` |
 | `workflows.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `workflows.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `workflows.resources.limits.memory` | Resources memory limit | `128M` |
+| `workflows.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `workflows.resources.requests.cpu` | Resources CPU request | `10m` |
-| `workflows.resources.requests.memory` | Resources memory request | `64M` |
+| `workflows.resources.requests.memory` | Resources memory request | `64Mi` |
 | `workflows.service.name` | Name of the service | `mender-workflows-server` |
 | `workflows.service.annotations` | Annotations map for the service | `{}` |
 | `workflows.service.type` | Service type | `ClusterIP` |
@@ -753,9 +753,9 @@ The following table lists the parameters for the `create-artifact-worker` compon
 | `create_artifact_worker.replicas` | Number of replicas | `1` |
 | `create_artifact_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `create_artifact_worker.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `create_artifact_worker.resources.limits.memory` | Resources memory limit | `1024M` |
+| `create_artifact_worker.resources.limits.memory` | Resources memory limit | `1024Mi` |
 | `create_artifact_worker.resources.requests.cpu` | Resources CPU request | `100m` |
-| `create_artifact_worker.resources.requests.memory` | Resources memory request | `128M` |
+| `create_artifact_worker.resources.requests.memory` | Resources memory request | `128Mi` |
 | `create_artifact_worker.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `create_artifact_worker.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
 | `create_artifact_worker.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
@@ -784,9 +784,9 @@ The following table lists the parameters for the `auditlogs` component and their
 | `auditlogs.replicas` | Number of replicas | `1` |
 | `auditlogs.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `auditlogs.resources.limits.cpu` | Resources CPU limit | `50m` |
-| `auditlogs.resources.limits.memory` | Resources memory limit | `128M` |
+| `auditlogs.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `auditlogs.resources.requests.cpu` | Resources CPU request | `50m` |
-| `auditlogs.resources.requests.memory` | Resources memory request | `128M` |
+| `auditlogs.resources.requests.memory` | Resources memory request | `128Mi` |
 | `auditlogs.service.name` | Name of the service | `mender-auditlogs` |
 | `auditlogs.service.annotations` | Annotations map for the service | `{}` |
 | `auditlogs.service.type` | Service type | `ClusterIP` |
@@ -829,9 +829,9 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.replicas` | Number of replicas | `1` |
 | `iot_manager.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `iot_manager.resources.limits.cpu` | Resources CPU limit | `50m` |
-| `iot_manager.resources.limits.memory` | Resources memory limit | `128M` |
+| `iot_manager.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `iot_manager.resources.requests.cpu` | Resources CPU request | `50m` |
-| `iot_manager.resources.requests.memory` | Resources memory request | `128M` |
+| `iot_manager.resources.requests.memory` | Resources memory request | `128Mi` |
 | `iot_manager.service.name` | Name of the service | `mender-iot_manager` |
 | `iot_manager.service.annotations` | Annotations map for the service | `{}` |
 | `iot_manager.service.type` | Service type | `ClusterIP` |
@@ -875,9 +875,9 @@ The following table lists the parameters for the `deviceconnect` component and t
 | `deviceconnect.replicas` | Number of replicas | `1` |
 | `deviceconnect.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconnect.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `deviceconnect.resources.limits.memory` | Resources memory limit | `128M` |
+| `deviceconnect.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `deviceconnect.resources.requests.cpu` | Resources CPU request | `100m` |
-| `deviceconnect.resources.requests.memory` | Resources memory request | `128M` |
+| `deviceconnect.resources.requests.memory` | Resources memory request | `128Mi` |
 | `deviceconnect.service.name` | Name of the service | `mender-deviceconnect` |
 | `deviceconnect.service.annotations` | Annotations map for the service | `{}` |
 | `deviceconnect.service.type` | Service type | `ClusterIP` |
@@ -922,9 +922,9 @@ The following table lists the parameters for the `deviceconfig` component and th
 | `deviceconfig.replicas` | Number of replicas | `1` |
 | `deviceconfig.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `deviceconfig.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `deviceconfig.resources.limits.memory` | Resources memory limit | `128M` |
+| `deviceconfig.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `deviceconfig.resources.requests.cpu` | Resources CPU request | `100m` |
-| `deviceconfig.resources.requests.memory` | Resources memory request | `128M` |
+| `deviceconfig.resources.requests.memory` | Resources memory request | `128Mi` |
 | `deviceconfig.service.name` | Name of the service | `mender-deviceconfig` |
 | `deviceconfig.service.annotations` | Annotations map for the service | `{}` |
 | `deviceconfig.service.type` | Service type | `ClusterIP` |
@@ -967,9 +967,9 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.replicas` | Number of replicas | `1` |
 | `devicemonitor.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `devicemonitor.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `devicemonitor.resources.limits.memory` | Resources memory limit | `128M` |
+| `devicemonitor.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `devicemonitor.resources.requests.cpu` | Resources CPU request | `100m` |
-| `devicemonitor.resources.requests.memory` | Resources memory request | `128M` |
+| `devicemonitor.resources.requests.memory` | Resources memory request | `128Mi` |
 | `devicemonitor.service.name` | Name of the service | `mender-devicemonitor` |
 | `devicemonitor.service.annotations` | Annotations map for the service | `{}` |
 | `devicemonitor.service.type` | Service type | `ClusterIP` |
@@ -1016,9 +1016,9 @@ The following table lists the parameters for the `generate-delta-worker` compone
 | `generate_delta_worker.replicas` | Number of replicas | `1` |
 | `generate_delta_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `generate_delta_worker.resources.limits.cpu` | Resources CPU limit | `100m` |
-| `generate_delta_worker.resources.limits.memory` | Resources memory limit | `1024M` |
+| `generate_delta_worker.resources.limits.memory` | Resources memory limit | `1024Mi` |
 | `generate_delta_worker.resources.requests.cpu` | Resources CPU request | `100m` |
-| `generate_delta_worker.resources.requests.memory` | Resources memory request | `128M` |
+| `generate_delta_worker.resources.requests.memory` | Resources memory request | `128Mi` |
 | `generate_delta_worker.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `nil` |
 | `generate_delta_worker.updateStrategy` | The strategy to use to update existing pods | `nil` |
 
@@ -1036,9 +1036,9 @@ The following table lists the parameters for the `redis` component and their def
 | `redis.replicas` | Number of replicas | `1` |
 | `redis.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `redis.resources.limits.cpu` | Resources CPU limit | `50m` |
-| `redis.resources.limits.memory` | Resources memory limit | `64M` |
+| `redis.resources.limits.memory` | Resources memory limit | `64Mi` |
 | `redis.resources.requests.cpu` | Resources CPU request | `100m` |
-| `redis.resources.requests.memory` | Resources memory request | `128M` |
+| `redis.resources.requests.memory` | Resources memory request | `128Mi` |
 | `redis.service.name` | Name of the service | `mender-redis` |
 | `redis.service.annotations` | Annotations map for the service | `{}` |
 | `redis.service.type` | Service type | `ClusterIP` |

--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ The following table lists the parameters for the `inventory` component and their
 | `inventory.migrationRestartPolicy` | Migration job: restartPolicy option | `Never` |
 | `inventory.migrationResources` | Migration job: optional K8s resources. If not specified, uses the deployment resources | `nil` |
 | `inventory.updateStrategy` | The strategy to use to update existing pods | `nil` |
+| `inventory.mongodbExistingSecret` | Use a different MongoDB secret for this service | `nil` |
 
 ### Parameters: reporting
 

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Mender Helm chart
 
-## Version 5.6.3
+## Version 5.7.0
 * `generate_delta_worker`: don't enforce tags for the image.
 * Added `api_gateway.accesslogs` parameter to enable/disable access logs.
 * Bump traefik image to v2.11.2
 * Move from megabytes to mebibytes for consistency.
+* Added `inventory.mongodbExistingSecret` to override the default MongoDB secret.
 
 ## Version 5.6.2
 * Upgrade to Mender version `3.7.4`.

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 5.6.3
 * `generate_delta_worker`: don't enforce tags for the image.
+* Added `api_gateway.accesslogs` parameter to enable/disable access logs.
 
 ## Version 5.6.2
 * Upgrade to Mender version `3.7.4`.

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 5.6.3
 * `generate_delta_worker`: don't enforce tags for the image.
 * Added `api_gateway.accesslogs` parameter to enable/disable access logs.
+* Bump traefik image to v2.11.2
 
 ## Version 5.6.2
 * Upgrade to Mender version `3.7.4`.

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.6.3
+* `generate_delta_worker`: don't enforce tags for the image.
+
 ## Version 5.6.2
 * Upgrade to Mender version `3.7.4`.
 

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -4,6 +4,7 @@
 * `generate_delta_worker`: don't enforce tags for the image.
 * Added `api_gateway.accesslogs` parameter to enable/disable access logs.
 * Bump traefik image to v2.11.2
+* Move from megabytes to mebibytes for consistency.
 
 ## Version 5.6.2
 * Upgrade to Mender version `3.7.4`.

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.4"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.6.2
+version: 5.6.3
 keywords:
   - mender
   - iot

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.4"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.6.3
+version: 5.7.0
 keywords:
   - mender
   - iot

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -111,7 +111,7 @@ MongoDB URI
         {{- printf "mongodb://%s" ( include "mongodb.service.nameOverride" .Subcharts.mongodb ) | b64enc | quote -}}
       {{- end }}
     {{- else }}
-      {{- fail "Failed: not implemented here." }}      
+      {{- fail "Failed: not implemented here." }}
     {{- end }}
   {{- else }}
     {{- printf .Values.global.mongodb.URL | b64enc | quote }}
@@ -328,4 +328,3 @@ Storage Proxy Rule
 {{- define "mender.storageProxyRule" -}}
   {{- default "HostRegexp(`{domain:^artifacts.*$}`)" .Values.api_gateway.storage_proxy.customRule | quote }}
 {{- end -}}
-

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -66,8 +66,10 @@ spec:
         securityContext: {{- omit .Values.api_gateway.containerSecurityContext "enabled" | toYaml | nindent 10 }}
 {{- end }}
         args:
+{{- if .Values.api_gateway.accesslogs }}
             - --accesslog=true
             - --accesslog.format=json
+{{- end }}
 {{- if .Values.api_gateway.dashboard }}
             - --api=true
             - --api.dashboard=true

--- a/mender/templates/inventory/_podtemplate.yaml
+++ b/mender/templates/inventory/_podtemplate.yaml
@@ -93,7 +93,11 @@ spec:
     envFrom:
     - prefix: INVENTORY_
       secretRef:
+      {{- if .dot.Values.inventory.mongodbExistingSecret }}
+        name: {{ .dot.Values.global.mongodb.existingSecret | default (ternary .dot.Values.inventory.mongodbExistingSecret "mongodb-common-prerelease" (empty .migration)) }}
+      {{- else }}
         name: {{ .dot.Values.global.mongodb.existingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
+      {{- end }}
 
     {{- if not (and ( le (int (include "menderVersionMajor" .)) 3 ) ( lt (int (include "menderVersionMinor" .)) 7 ) ) }}
     {{- if and .dot.Values.global.redis.existingSecret .dot.Values.global.enterprise ( not .dot.Values.global.redis.URL ) ( not .dot.Values.redis.enabled ) }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -198,7 +198,7 @@ api_gateway:
   image:
     registry: docker.io
     repository: traefik
-    tag: v2.11.0
+    tag: v2.11.2
     imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   replicas: 1

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -205,10 +205,10 @@ api_gateway:
   resources:
     limits:
       cpu: 600m
-      memory: 1G
+      memory: 1Gi
     requests:
       cpu: 600m
-      memory: 512M
+      memory: 512Mi
   affinity: {}
   nodeSelector: {}
   httpPort: 9080
@@ -280,10 +280,10 @@ deployments:
   resources:
     limits:
       cpu: 300m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 300m
-      memory: 64M
+      memory: 64Mi
   affinity: {}
   directUpload:
     enabled: true
@@ -328,10 +328,10 @@ deployments:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -353,10 +353,10 @@ device_auth:
   resources:
     limits:
       cpu: 350m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 350m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: ""
@@ -408,10 +408,10 @@ device_auth:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -436,10 +436,10 @@ generate_delta_worker:
   resources:
     limits:
       cpu: 100m
-      memory: 1024M
+      memory: 1024Mi
     requests:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: registry.mender.io
@@ -468,10 +468,10 @@ gui:
   resources:
     limits:
       cpu: 20m
-      memory: 64M
+      memory: 64Mi
     requests:
       cpu: 5m
-      memory: 16M
+      memory: 16Mi
   affinity: {}
   image:
     registry: docker.io
@@ -516,10 +516,10 @@ inventory:
   resources:
     limits:
       cpu: 300m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 300m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: ""
@@ -557,10 +557,10 @@ inventory:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # inventory.updateStrategy: Strategy to use to update existing pods
   # Example:
@@ -581,10 +581,10 @@ tenantadm:
   resources:
     limits:
       cpu: 150m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 150m
-      memory: 64M
+      memory: 64Mi
   affinity: {}
   image:
     registry: registry.mender.io
@@ -637,10 +637,10 @@ tenantadm:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -662,10 +662,10 @@ useradm:
   resources:
     limits:
       cpu: 150m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 150m
-      memory: 64M
+      memory: 64Mi
   affinity: {}
   image:
     registry: ""
@@ -717,10 +717,10 @@ useradm:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -742,10 +742,10 @@ workflows:
   resources:
     limits:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 10m
-      memory: 64M
+      memory: 64Mi
   affinity: {}
   image:
     registry: ""
@@ -779,10 +779,10 @@ workflows:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128MI
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -819,10 +819,10 @@ create_artifact_worker:
   resources:
     limits:
       cpu: 100m
-      memory: 1024M
+      memory: 1024Mi
     requests:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: docker.io
@@ -863,10 +863,10 @@ auditlogs:
   resources:
     limits:
       cpu: 50m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 50m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: registry.mender.io
@@ -902,10 +902,10 @@ auditlogs:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -927,10 +927,10 @@ iot_manager:
   resources:
     limits:
       cpu: 50m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 50m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: docker.io
@@ -966,10 +966,10 @@ iot_manager:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -996,10 +996,10 @@ deviceconnect:
   resources:
     limits:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: docker.io
@@ -1037,10 +1037,10 @@ deviceconnect:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -1062,10 +1062,10 @@ deviceconfig:
   resources:
     limits:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: docker.io
@@ -1101,10 +1101,10 @@ deviceconfig:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []
@@ -1126,10 +1126,10 @@ devicemonitor:
   resources:
     limits:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
     requests:
       cpu: 100m
-      memory: 128M
+      memory: 128Mi
   affinity: {}
   image:
     registry: registry.mender.io
@@ -1168,10 +1168,10 @@ devicemonitor:
   # migrationResources:
   #   limits:
   #     cpu: 150m
-  #     memory: 128M
+  #     memory: 128Mi
   #   requests:
   #     cpu: 150m
-  #     memory: 64M
+  #     memory: 64Mi
 
   # custom envs
   customEnvs: []

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -512,6 +512,7 @@ inventory:
   enabled: true
   podAnnotations: {}
   automigrate: true
+  mongodbExistingSecret: ""
   replicas: 1
   resources:
     limits:

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -253,6 +253,7 @@ api_gateway:
   hpa: {}
   pdb: {}
   priorityClassName: ""
+  accesslogs: true
   certs: {}
   # cert: |-
   #   -----BEGIN CERTIFICATE-----

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -443,7 +443,6 @@ generate_delta_worker:
   image:
     registry: registry.mender.io
     repository: mendersoftware/generate-delta-worker
-    tag: mender-3.5.0
     imagePullPolicy: IfNotPresent
   imagePullSecrets: []
   nodeSelector: {}


### PR DESCRIPTION
* `generate_delta_worker`: don't enforce tags for the image.
* Added `api_gateway.accesslogs` parameter to enable/disable access logs.
* Bump traefik image to v2.11.2
* Move from megabytes to mebibytes for consistency.
* Added `inventory.mongodbExistingSecret` to override the default MongoDB secret.