### PR TITLE
fix: mongodb override with global existingsecret

### DIFF
--- a/mender/templates/inventory/_podtemplate.yaml
+++ b/mender/templates/inventory/_podtemplate.yaml
@@ -94,7 +94,7 @@ spec:
     - prefix: INVENTORY_
       secretRef:
       {{- if .dot.Values.inventory.mongodbExistingSecret }}
-        name: {{ .dot.Values.global.mongodb.existingSecret | default (ternary .dot.Values.inventory.mongodbExistingSecret "mongodb-common-prerelease" (empty .migration)) }}
+        name: {{ .dot.Values.inventory.mongodbExistingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
       {{- else }}
         name: {{ .dot.Values.global.mongodb.existingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
       {{- end }}


### PR DESCRIPTION
When a global.mongodb.existingSecret is set, the mongodb override for the inventory doesn't work. This fixes it.

Ticket: MC-7302