### PR TITLE
allow overriding name and fullname

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ The following table lists the global, default, and other parameters supported by
 | `serviceAccount.name` | Custom ServiceAccount name | `nil` |
 | `serviceAccount.labels` | ServiceAccount labels | `nil` |
 | `serviceAccount.annotations` | ServiceAccount annotations | `nil` |
+| `fullnameOverride` | Use a custom prefix for the resources, instead of using the helm chart name (default) | `nil` |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -12,7 +12,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "mender.fullname" -}}
-{{- if contains .Chart.Name .Release.Name }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride }}
+{{- else if contains .Chart.Name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -1,3 +1,5 @@
+fullnameOverride: ""
+
 global:
   enterprise: true
   hosted: false


### PR DESCRIPTION
we're packaging mender as a sub-chart. which resulted in a relatively long chart names combination:

```
Invalid value: `our-custom-helm-chart-mender-deployments-storage-daemon` must be no more than 52 characters
```