### PR TITLE
Fix naming problem in templates using api_gateway and NodePort

### DIFF
--- a/mender/templates/api-gateway/service.yaml
+++ b/mender/templates/api-gateway/service.yaml
@@ -30,7 +30,7 @@ spec:
   - port: {{ .Values.api_gateway.service.httpsPort }}
     protocol: TCP
     targetPort: {{ .Values.api_gateway.httpsPort }}
-    {{- if .Values.api_gateway.httpsNodePort }}
+    {{- if .Values.api_gateway.service.httpsNodePort }}
     nodePort: {{ .Values.api_gateway.service.httpsNodePort }}
     {{- end }}
     name: https


### PR DESCRIPTION
The template checks for a value that is different from the one using in the line after to set the value.

Looking into how it is done for http just below seems like a typo to me.