### PR TITLE
Added tenantadm and iotmanager CronJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,13 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.probesOverrides.successThreshold` | Override the `successThreshold` for every Readiness and Liveness probes. | `nil` |
 | `tenantadm.probesOverrides.timeoutSeconds` | Override the `timeoutSeconds` for every Readiness and Liveness probes. | `nil` |
 | `tenantadm.probesOverrides.failureThreshold` | Override the `failureThreshold` for every Readiness and Liveness probes. | `nil` |
+| `tenantadm.cronjobs.suspendTenants.enabled` | Creates the Suspend Tenants cronjob (Hosted only) | `false` |
+| `tenantadm.cronjobs.suspendTenants.schedule` | Set a schedule for the Suspend Tenants cronjob (Hosted only) | `0 7 * * *` |
+| `tenantadm.cronjobs.suspendTenants.resouces` | Set the resources for the Suspend Tenants cronjob (Hosted only) | `nil` |
+| `tenantadm.cronjobs.syncTenants.enabled` | Creates the Suspend Tenants cronjob (Hosted only) | `false` |
+| `tenantadm.cronjobs.syncTenants.schedule` | Set a schedule for the Suspend Tenants cronjob (Hosted only) | `0 7 * * *` |
+| `tenantadm.cronjobs.syncTenants.resouces` | Set the resources for the Suspend Tenants cronjob (Hosted only) | `nil` |
+
 
 The default value for the rate limits are:
 

--- a/README.md
+++ b/README.md
@@ -900,6 +900,9 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.probesOverrides.successThreshold` | Override the `successThreshold` for every Readiness and Liveness probes. | `nil` |
 | `iot_manager.probesOverrides.timeoutSeconds` | Override the `timeoutSeconds` for every Readiness and Liveness probes. | `nil` |
 | `iot_manager.probesOverrides.failureThreshold` | Override the `failureThreshold` for every Readiness and Liveness probes. | `nil` |
+| `iot_manager.cronjobs.syncDevices.enabled` | Creates the Sync Devices cronjob (Hosted only) | `false` |
+| `iot_manager.cronjobs.syncDevices.schedule` | Set a schedule for the Sync Devices cronjob (Hosted only) | `0 7 * * *` |
+| `iot_manager.cronjobs.syncDevices.resouces` | Set the resources for the Sync Devices cronjob (Hosted only) | `nil` |
 
 ### Parameters: deviceconnect
 

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 5.7.1
 * Added tenantadm CronJobs (Hosted only feature)
+* Added iot-manager CronJobs (Hosted only feature)
 
 ## Version 5.7.0
 * `generate_delta_worker`: don't enforce tags for the image.

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.7.1
+* Added tenantadm CronJobs (Hosted only feature)
+
 ## Version 5.7.0
 * `generate_delta_worker`: don't enforce tags for the image.
 * Added `api_gateway.accesslogs` parameter to enable/disable access logs.

--- a/mender/templates/iot-manager/_podtemplate.yaml
+++ b/mender/templates/iot-manager/_podtemplate.yaml
@@ -22,7 +22,13 @@ spec:
   restartPolicy: {{ quote . }}
   {{- end }}
   containers:
-  - name: {{ ternary "iot-manager" "iot-manager-migration" (empty .migration) | quote }}
+  {{- if .migration }}
+  - name: "iot-manager-migration"
+  {{- else if .cronjob }}
+  - name: "iot-manager-{{- .cronjob }}"
+  {{- else }}
+  - name: "iot-manager"
+  {{- end }}
     image: {{ .dot.Values.iot_manager.image.registry }}/{{ .dot.Values.iot_manager.image.repository }}:{{ .dot.Values.iot_manager.image.tag | default .dot.Values.global.image.tag }}
     imagePullPolicy: {{ .dot.Values.iot_manager.image.imagePullPolicy }}
     {{- if .dot.Values.iot_manager.containerSecurityContext.enabled }}
@@ -33,7 +39,9 @@ spec:
     resources: {{- nindent 6 . }}
     {{- end }}
 
-    {{- if (not .migration) }}
+    {{- if .args }}
+    args: {{- toYaml .args | nindent 6 }}
+    {{- else if (not .migration) }}
     {{- if .dot.Values.iot_manager.automigrate }}
     args: ["server", "--automigrate"]
     {{- else }}
@@ -44,7 +52,7 @@ spec:
     {{- end }}
 
 
-    {{- if (not .migration) }}
+    {{- if and (not .migration) (not .cronjob) }}
     # Readiness/liveness probes
     readinessProbe:
       httpGet:

--- a/mender/templates/iot-manager/cronjob.yaml
+++ b/mender/templates/iot-manager/cronjob.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.iot_manager.enabled) (.Values.global.hosted) (.Values.iot_manager.cronjobs.syncDevices.enabled) }}
+---
+# Suspend tenants: maintenance suspend-expired-tenants
+
+{{- $context := (dict "dot" . "component" "iot-manager" "cronjob" "sync-devices" "args" (list "sync-devices" "--batch-size" "100") "extraResources" .Values.iot_manager.cronjobs.syncDevices.resources "restartPolicy" "Never") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "mender.fullname" . }}-iot-manager-sync-devices
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-iot-manager-sync-devices
+    app.kubernetes.io/component: iot-manager
+spec:
+  schedule: {{ .Values.iot_manager.cronjobs.syncDevices.schedule }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+
+  jobTemplate:
+    spec:
+      template:
+        {{- include "mender.iotmanagerPodTemplate" $context | nindent 8 }}
+
+{{- end }}
+

--- a/mender/templates/tenantadm/_podtemplate.yaml
+++ b/mender/templates/tenantadm/_podtemplate.yaml
@@ -22,7 +22,13 @@ spec:
   restartPolicy: {{ quote . }}
   {{- end }}
   containers:
-  - name: {{ ternary "tenantadm" "tenantadm-migration" (empty .migration) | quote }}
+  {{- if .migration }}
+  - name: "tenantadm-migration"
+  {{- else if .cronjob }}
+  - name: "tenantadm-{{- .cronjob }}"
+  {{- else }}
+  - name: "tenantadm"
+  {{- end }}
     image: {{ .dot.Values.tenantadm.image.registry }}/{{ .dot.Values.tenantadm.image.repository }}:{{ .dot.Values.tenantadm.image.tag | default .dot.Values.global.image.tag }}
     imagePullPolicy: {{ .dot.Values.tenantadm.image.imagePullPolicy }}
     {{- if .dot.Values.tenantadm.containerSecurityContext.enabled }}
@@ -40,7 +46,7 @@ spec:
     {{- end }}
 
 
-    {{- if (not .migration) }}
+    {{- if and (not .migration) (not .cronjob) }}
     # Readiness/liveness probes
     readinessProbe:
       httpGet:
@@ -66,7 +72,7 @@ spec:
       periodSeconds: 5
     {{- end }}
 
-    {{- if (not .migration) }}
+    {{- if and (not .migration) (not .cronjob) }}
     volumeMounts:
     - name: rsa
       mountPath: "/etc/tenantadm/rsa/"
@@ -102,7 +108,7 @@ spec:
   nodeSelector: {{ toYaml . | nindent 4 }}
   {{- end }}
 
-  {{- if (not .migration) }}
+  {{- if and (not .migration) (not .cronjob) }}
   volumes:
   - name: rsa
     secret:

--- a/mender/templates/tenantadm/cronjob.yaml
+++ b/mender/templates/tenantadm/cronjob.yaml
@@ -1,0 +1,79 @@
+{{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) (.Values.global.hosted) (.Values.tenantadm.cronjobs.suspendTenants.enabled) }}
+---
+# Suspend tenants: maintenance suspend-expired-tenants
+
+{{- $context := (dict "dot" . "component" "tenantadm" "cronjob" "suspend" "args" (list "maintenance" "suspend-expired-tenants") "extraResources" .Values.tenantadm.cronjobs.suspendTenants.resources "restartPolicy" "Never") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "mender.fullname" . }}-tenantadm-suspend-trial
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-tenantadm-suspend-trial
+    app.kubernetes.io/component: tenantadm
+spec:
+  schedule: {{ .Values.tenantadm.cronjobs.suspendTenants.schedule }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+
+  jobTemplate:
+    spec:
+      template:
+        {{- include "mender.tenantadmPodTemplate" $context | nindent 8 }}
+
+
+---
+# Suspend trial tenants: suspend-tenants-expired-trial
+
+{{- $context := (dict "dot" . "component" "tenantadm" "cronjob" "suspend" "args" (list "suspend-tenants-expired-trial") "extraResources" .Values.tenantadm.cronjobs.suspendTenants.resources "restartPolicy" "Never") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "mender.fullname" . }}-tenantadm-suspend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-tenantadm-suspend
+    app.kubernetes.io/component: tenantadm
+spec:
+  schedule: {{ .Values.tenantadm.cronjobs.suspendTenants.schedule }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+
+  jobTemplate:
+    spec:
+      template:
+        {{- include "mender.tenantadmPodTemplate" $context | nindent 8 }}
+
+
+{{- end }}
+
+{{- if and (.Values.global.enterprise) (.Values.tenantadm.enabled) (.Values.global.hosted) (.Values.tenantadm.cronjobs.syncTenants.enabled) }}
+---
+# Sync tenants with an external integration
+
+{{- $context := (dict "dot" . "component" "tenantadm" "cronjob" "sync-tenants" "args" (list "sync-tenants") "extraResources" .Values.tenantadm.cronjobs.syncTenants.resources "restartPolicy" "Never") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "mender.fullname" . }}-tenantadm-sync-tenants
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-tenantadm-sync-tenants
+    app.kubernetes.io/component: tenantadm
+spec:
+  schedule: {{ .Values.tenantadm.cronjobs.suspendTenants.schedule }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+
+  jobTemplate:
+    spec:
+      template:
+        {{- include "mender.tenantadmPodTemplate" $context | nindent 8 }}
+
+{{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -705,6 +705,30 @@ tenantadm:
     # successThreshold: 2
     # failureThreshold: 6
 
+  cronjobs:
+    # suspend tenants cronjobs: these cronjobs are used to suspend expired trial tenants
+    suspendTenants:
+      enabled: false
+      schedule: "0 7 * * *"
+      # resources:
+      #   limits:
+      #     cpu: 300m
+      #     memory: 200Mi
+      #   requests:
+      #     cpu: 50m
+      #     memory: 50Mi
+    # sync tenants cronjob to sync with an external integration
+    syncTenants:
+      enabled: false
+      schedule: "0 8 * * *"
+      # resources:
+      #   limits:
+      #     cpu: 300m
+      #     memory: 200Mi
+      #   requests:
+      #     cpu: 50m
+      #     memory: 50Mi
+
 useradm:
   enabled: true
   podAnnotations: {}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -1087,6 +1087,18 @@ iot_manager:
     # successThreshold: 2
     # failureThreshold: 6
 
+  cronjobs:
+    # sync devices cronjob
+    syncDevices:
+      enabled: false
+      schedule: "42 0 * * *"
+      # resources:
+      #   limits:
+      #     cpu: 150m
+      #   requests:
+      #     cpu: 150m
+      #     memory: 64M
+
 deviceconnect:
   enabled: true
   podAnnotations: {}


### PR DESCRIPTION
This is an Hosted only feature: cronjobs to maintain tenants

Ticket: MC-7433

Hosted Mender alignements:
* `cronjob-mender-tenantadm-suspend-expired.yaml` originally contains two containers: this is splitted into two different CronJobs with the same schedules and the two different containers: this for reusing the _podtemplate
* `cronjob-mender-tenantadm-sync-tenants.yaml`
* `cronjob-iot-manager-sync-devices.yaml`
