### PR TITLE
chore: bump default nats image to 2.9.20

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 5.7.1
 * Fix: SMTP variables when using an external secret, added to `global.smtp.existingSecret`
+* Fix: the NATS image were not aligned with the subchart version
 
 ## Version 5.7.0
 * `generate_delta_worker`: don't enforce tags for the image.

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -188,7 +188,7 @@ nats:
     replicas: 3
   fullnameOverride: ""
   nats:
-    image: "nats:2.7.4-scratch"
+    image: "nats:2.9.20-scratch"
     jetstream:
       enabled: true
       memStorage:


### PR DESCRIPTION
Ticket: MC-7459