### PR TITLE
fix: display integrations button on 3.6

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.8.3
+* Fix: correctly setup the Integration Version.
+
 ## Version 5.8.2
 * Fix: correctly setup the Mender Version in the iot-manager service.
 

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.4"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.8.2
+version: 5.8.3
 keywords:
   - mender
   - iot

--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -89,6 +89,8 @@ spec:
           value: {{ .Values.global.enterprise | quote }}
         - name: MENDER_VERSION
           value: {{ trimPrefix "mender-" .Values.global.image.tag | quote }}
+        - name: INTEGRATION_VERSION
+          value: {{ trimPrefix "mender-" .Values.global.image.tag | quote }}
         {{- end }}
         {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: HAVE_AUDITLOGS


### PR DESCRIPTION
This fix allows displaying the integration button on the Mender 3.6 release

Ticket: None