### PR TITLE
Generate delta worker mongo secret

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mender Helm chart
 
+## Version 5.9.2
+* Fix: generate delta worker mongodb secret when using an external secret and
+  the mongodb subchart is enabled.
+
 ## Version 5.9.1
 * Upgrade to Mender version `3.7.5`
 

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.5"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.9.1
+version: 5.9.2
 keywords:
   - mender
   - iot

--- a/mender/templates/generate-delta-worker/deployment.yaml
+++ b/mender/templates/generate-delta-worker/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
-            name: mongodb-common
+            name: {{ .Values.global.mongodb.existingSecret | default "mongodb-common" }}
 
         {{- if .Values.global.nats.existingSecret }}
         - prefix: WORKFLOWS_


### PR DESCRIPTION
Fix using an external secret in the generate delta worker service, when using MongoDB subchart.

Ticket: MC-7496