### PR TITLE
feat: Change `generate-delta-worker` to StatefulSet and add persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,12 @@ The following table lists the parameters for the `generate-delta-worker` compone
 | `generate_delta_worker.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
 | `generate_delta_worker.podAnnotations` | add custom pod annotations | `nil` |
 | `generate_delta_worker.replicas` | Number of replicas | `1` |
+| `generate_delta_worker.persistence.enabled` | Enable persistence of the work directory (PVC template) | `true` |
+| `generate_delta_worker.persistence.accessModes` | Access modes for the volumes created by the StatefulSet | `["ReadWriteOnce"]` |
+| `generate_delta_worker.persistence.size` | Size of the volumes (per replica) | `40Gi` |
+| `generate_delta_worker.persistence.storageClass` | Storage class for the volumes created by the StatefulSet | `""` (default) |
+| `generate_delta_worker.persistence.retention.whenDeleted` | Volume retention policy when StatefulSet is deleted | `"Retain"` |
+| `generate_delta_worker.persistence.retention.whenScaled` | Volume retention policy when StatefulSet is scaled (down) | `"Delete"` |
 | `generate_delta_worker.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |
 | `generate_delta_worker.resources.limits.cpu` | Resources CPU limit | `100m` |
 | `generate_delta_worker.resources.limits.memory` | Resources memory limit | `1024Mi` |

--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mender Helm chart
 
+## Version 5.10.0
+* Change `generate_delta_worker` to StatefulSet and add `persistence` values
+  * The new `persistence` values specifies the parameters of the PVC template of
+    the statefulset.
+
 ## Version 5.9.4
 * Update default traefik tag to v2.11.6
 

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.5"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.9.4
+version: 5.10.0
 keywords:
   - mender
   - iot

--- a/mender/templates/generate-delta-worker/service.yaml
+++ b/mender/templates/generate-delta-worker/service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.global.enterprise .Values.generate_delta_worker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mender.fullname" . }}-generate-delta-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-generate-delta-worker
+    app.kubernetes.io/component: generate-delta-worker
+{{- with .Values.deployments.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: "None"
+  ports: []
+  selector:
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-generate-delta-worker
+{{- end }}

--- a/mender/templates/generate-delta-worker/statefulset.yaml
+++ b/mender/templates/generate-delta-worker/statefulset.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.global.enterprise .Values.generate_delta_worker.enabled }}
 {{- $merged := merge (deepCopy .Values.generate_delta_worker) (deepCopy (default (dict) .Values.default)) -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "mender.fullname" . }}-generate-delta-worker
   namespace: {{ .Release.Namespace }}
@@ -10,7 +10,15 @@ metadata:
     app.kubernetes.io/name: {{ include "mender.fullname" . }}-generate-delta-worker
     app.kubernetes.io/component: generate-delta-worker
 spec:
+  serviceName: {{ include "mender.fullname" . }}-generate-delta-worker
   replicas: {{ .Values.generate_delta_worker.replicas }}
+
+  # Rollout upgrade
+  {{- $updateStrategy := coalesce .Values.generate_delta_worker.updateStrategy .Values.default.updateStrategy }}
+  {{- if $updateStrategy }}
+  updateStrategy: {{- toYaml $updateStrategy | nindent 4 }}
+  {{- end }}
+
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "mender.fullname" . }}-generate-delta-worker
@@ -20,10 +28,28 @@ spec:
   # needs to be big enough to rollout to complete
   progressDeadlineSeconds: 600
 
-  # Rollout upgrade
-  {{- $updateStrategy := coalesce .Values.generate_delta_worker.updateStrategy .Values.default.updateStrategy }}
-  {{- if $updateStrategy }}
-  strategy: {{- toYaml $updateStrategy | nindent 4 }}
+  {{- with .Values.generate_delta_worker.persistence }}
+  {{- if .enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        {{- if .accessModes }}
+        accessModes:
+          {{- .accessModes | toYaml | nindent 14 }}
+        {{- else }}
+        accessModes: [ "ReadWriteOnce" ]
+        {{- end }}
+        {{- with .storageClass }}
+        storageClassName: {{ quote . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ default .size "40Gi" }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ default .retention.whenDeleted "Retain" | quote }}
+    whenScaled: {{ default .retention.whenScaled "Delete" | quote }}
+  {{- end }}
   {{- end }}
 
   template:
@@ -76,6 +102,13 @@ spec:
         - name: GENERATE_DELTA_DEPLOYMENTS_URL
           value: http://{{ .Values.deployments.service.name }}:{{ .Values.deployments.service.port }}
         {{- include "mender.customEnvs" (merge (deepCopy .Values.generate_delta_worker) (deepCopy (default (dict) .Values.default))) | nindent 8 }}
+        {{- with .Values.generate_delta_worker.persistence }}
+        {{- if .enabled }}
+        {{- /* If persistence is enabled, the work path must be predictable */}}
+        - name: GENERATE_DELTA_WORKDIR
+          value: /work
+        {{- end }}
+        {{- end }}
         envFrom:
         - prefix: WORKFLOWS_
           secretRef:
@@ -85,6 +118,13 @@ spec:
         - prefix: WORKFLOWS_
           secretRef:
             name: {{ .Values.global.nats.existingSecret }}
+        {{- end }}
+        {{- with .Values.generate_delta_worker.persistence }}
+        {{- if .enabled }}
+        volumeMounts:
+          - name: workspace
+            mountPath: /work
+        {{- end }}
         {{- end }}
 
 {{- if .Values.global.image.username }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -471,6 +471,20 @@ generate_delta_worker:
   podAnnotations: {}
   automigrate: false
   replicas: 1
+  # persistence specifies parameters for the pvc templates created for the
+  # stateful set.
+  persistence:
+    # enabled adds pvc templates to the StatefulSet definition.
+    # If disabled, the service will use ephermeral storage.
+    enabled: true
+    accessModes: ["ReadWriteOnce"]
+    size: "40Gi"
+    storageClass: ""
+    # retetion specifies the retention policy for the pvc created by the
+    # StatefulSet.
+    retention:
+      whenDeleted: "Retain"
+      whenScaled: "Delete"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Changes the `generate-delta-worker` workload from Deployment to StatefulSet and exposes volume claim template parameters in the values.