### PR TITLE
fix(traefik v3): Invalid host regex for default storage proxy URL

### DIFF
--- a/mender/CHANGELOG.md
+++ b/mender/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mender Helm chart
 
+## Version 5.10.1
+* Fix invalid regexp in default storage proxy rule.
+
 ## Version 5.10.0
 * Change `generate_delta_worker` to StatefulSet and add `persistence` values
   * The new `persistence` values specifies the parameters of the PVC template of

--- a/mender/Chart.yaml
+++ b/mender/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.7"
 description: Mender is a robust and secure way to update all your software and deploy your IoT devices at scale with support for customization
 name: mender
-version: 5.10.0
+version: 5.10.1
 keywords:
   - mender
   - iot

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -328,7 +328,7 @@ Define mender.storageProxyUrl
 Storage Proxy Rule
 */}}
 {{- define "mender.storageProxyRule" -}}
-  {{- default "HostRegexp(`{domain:^artifacts.*$}`)" .Values.api_gateway.storage_proxy.customRule | quote }}
+  {{- default "HostRegexp(`^artifacts.*$`)" .Values.api_gateway.storage_proxy.customRule | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
The regular expression in the hostname rule was using incompatible Traefik v2 regex.