### PR TITLE
fix: traefik container ports optionals

### DIFF
--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -1,13 +1,17 @@
 {{- if .Values.api_gateway.enabled }}
 {{- $merged := merge (deepCopy .Values.api_gateway) (deepCopy (default (dict) .Values.default)) -}}
 {{- if or .Values.api_gateway.podSecurityContext.enabled .Values.api_gateway.containerSecurityContext.enabled }}
-  {{- if lt (int .Values.api_gateway.httpPort) 1024  }}
+  {{- if and .Values.api_gateway.httpPort (lt (int .Values.api_gateway.httpPort) 1024)  }}
     {{- fail ".Values.api_gateway.httpPort can't be less than 1024 when Security Context is enabled" }}
   {{- end }}
-  {{- if lt (int .Values.api_gateway.httpsPort) 1024  }}
+  {{- if and .Values.api_gateway.httpsPort (lt (int .Values.api_gateway.httpsPort) 1024)  }}
     {{- fail ".Values.api_gateway.httpsPort can't be less than 1024 when Security Context is enabled" }}
   {{- end }}
 {{- end }}
+{{- if and .Values.api_gateway.env.SSL (not .Values.api_gateway.httpsPort) }}
+  {{- fail ".Values.api_gateway.httpsPort has to be set when .Values.api_gateway.env.SSL is enabled." }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,8 +79,12 @@ spec:
             - --api.dashboard=true
             - --api.insecure=true
 {{- end }}
+{{- if .Values.api_gateway.httpPort }}
             - --entrypoints.http.address=:{{- .Values.api_gateway.httpPort }}
+{{- end }}
+{{- if .Values.api_gateway.httpsPort }}
             - --entrypoints.https.address=:{{- .Values.api_gateway.httpsPort }}
+{{- end }}
             - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
@@ -98,7 +106,7 @@ spec:
 {{ toYaml .Values.api_gateway.resources | indent 10 }}
 
         ports:
-{{- if .Values.api_gateway.env.SSL }}
+{{- if and .Values.api_gateway.env.SSL .Values.api_gateway.httpsPort }}
         - containerPort: {{ .Values.api_gateway.httpsPort }}
 {{- end }}
         - containerPort: {{ .Values.api_gateway.httpPort }}


### PR DESCRIPTION
You can choose to not to set either httpPort or httpsPort in the api_gateway, to prevent upload timeout with the Mender Cli, as reported by customers.

Ticket: MEN-7595