### PR TITLE
ci: fix changelog append on top

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -858,13 +858,15 @@ changelog:
         --target-branch=${CI_COMMIT_REF_NAME}
     # git cliff: override the changelog
     - test $GIT_CLIFF == "false" && echo "INFO - Skipping git-cliff" && exit 0
-    - git clone https://${GITHUB_USER}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
-    - cd ${GITHUB_REPO_URL#*/}
+    - git remote add github https://${GITHUB_USER}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
+    - gh repo set-default https://${GITHUB_USER}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
     - RELEASE_PLEASE_PR=$(gh pr list --author "${GITHUB_USER_NAME}" --head "release-please--branches--${CI_COMMIT_REF_NAME}" --json number | jq -r '.[0].number // empty')
     - test -z "$RELEASE_PLEASE_PR" && echo "No release-please PR found" && exit 0
     - echo "INFO - generating changelog notes from git cliff"
         && gh pr checkout $RELEASE_PLEASE_PR
-        && git cliff --unreleased --output mender/CHANGELOG.md --bump --github-repo ${GITHUB_REPO_URL}
+        && git cliff --unreleased --bump --prepend mender/CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
+        && sed -i 's/# Mender Helm chart//' mender/CHANGELOG.md
+        && sed -i 's/---/# Mender Helm chart\n/' mender/CHANGELOG.md
         && git add mender/CHANGELOG.md
         && git commit --amend -s --no-edit
         && git push origin --force


### PR DESCRIPTION
With the --unreleased flag, only the last release were added to the CHANGELOG.md, so the old history would have been lost. With this change, we'll just prepend the new git cliff release.

[Wrong CHANGELOG patch](https://github.com/mendersoftware/mender-helm/pull/346/commits/da9a4ef2e668fa0fa057321e0aac287b01f38997#diff-d2cbe88096a4c24cd4a33d862fe49df122c543515c8b811b79f67818f655982e)

Likely good CHANGELOG patch:
```
# Mender Helm Chart


## 5.11.0 - 2024-10-07


### Features


- Add gui hpa ([8f6d9f4](https://github.com/mendersoftware/mender-helm.git/commit/8f6d9f46c0c9db16939a8c851ed4bda21e7ca5f3)) 
  Added Horizontal Pod Autoscaler resource to the gui container, to scale
  it automatically when the service experiences more load.

## Version 5.10.1
* Fix invalid regexp in default storage proxy rule.

## Version 5.10.0
* Change `generate_delta_worker` to StatefulSet and add `persistence` values
  * The new `persistence` values specifies the parameters of the PVC template of
    the statefulset.
* Upgrade Traefik to v3.1.2
* Upgrade to Mender version `3.7.7`
```