### PR TITLE
Fix release please - iteration #2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -849,8 +849,6 @@ changelog:
     - npm install -g git-cliff
     # GITHUB_TOKEN for Github cli authentication
     - export GITHUB_TOKEN=${GITHUB_CLI_TOKEN}
-    # getting the centralized git cliff config
-    - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
   script:
     - release-please release-pr
         --token=${GITHUB_BOT_TOKEN_REPO_FULL}
@@ -864,12 +862,11 @@ changelog:
     - test -z "$RELEASE_PLEASE_PR" && echo "No release-please PR found" && exit 0
     - echo "INFO - generating changelog notes from git cliff"
         && gh pr checkout $RELEASE_PLEASE_PR
-        && git cliff --unreleased --bump --prepend mender/CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
-        && sed -i 's/# Mender Helm chart//' mender/CHANGELOG.md
-        && sed -i 's/---/# Mender Helm chart\n/' mender/CHANGELOG.md
+        && wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
+        && git cliff --bump --output mender/CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
         && git add mender/CHANGELOG.md
         && git commit --amend -s --no-edit
-        && git push origin --force
+        && git push github --force
     # note: using sed to prevent release-please to mess up with the Github Release body
     - echo "INFO - updating PR body"
         && git cliff --unreleased --bump -o tmp_pr_body.md --github-repo ${GITHUB_REPO_URL}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": false,
   "bootstrap-sha": "bced4eecaebc707975b011d64bc28354367433c0",
+  "signoff": "mender-test-bot <mender@northern.tech>",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }
 


### PR DESCRIPTION
For some reason the `--prepend` option is not working well with the previous changelog: it is adding the new changes in the [middle of the changelog file](https://github.com/mendersoftware/mender-helm/pull/346/files#diff-d2cbe88096a4c24cd4a33d862fe49df122c543515c8b811b79f67818f655982eR79). 
For this reason my purpose is to generate the full changelog history, also to adhere fully to the new standard.

Also, this fixes the commit signoff missing

