### PR TITLE
ci: not running changelog job during playground

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -828,6 +828,8 @@ changelog:
       when: never
     - if: $RUN_RELEASE == "true"
       when: never
+    - if: '$RUN_PLAYGROUND == "true"'
+      when: never
     - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/"
     - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
   before_script:
@@ -879,6 +881,8 @@ release:github:
     - hetzner-amd-beefy
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: '$RUN_PLAYGROUND == "true"'
       when: never
     - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/" && $RUN_RELEASE == "true"
     - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH && $RUN_RELEASE == "true"


### PR DESCRIPTION
The playground option is needed to run an EKS cluster to manually play with, and a Changelog job is useless here.