### PR TITLE
ci: prerelease support to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,9 @@
     }
   },
   "release-type": "helm",
+  "versioning": "prerelease",
+  "prerelease": true,
+  "prerelease-type": "rc",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
   "bootstrap-sha": "bced4eecaebc707975b011d64bc28354367433c0",


### PR DESCRIPTION
Enable prerelease tags; this is the default for every master commit. If you want to create a stable release, you have to create a Release-As<colon> <your release version>

Ticket: QA-795
Changelog: None