### PR TITLE
ci: fix seaweedfs filer data storage

### DIFF
--- a/tests/seaweedfs.yaml
+++ b/tests/seaweedfs.yaml
@@ -7,7 +7,8 @@ filer:
     enableAuth: true
     createBuckets:
       - name: "mender-artifacts-seaweedfs"
-  storageClass: "gp2"
+  data:
+    type: "emptyDir"
 s3:
   enabled: true
   enableAuth: true


### PR DESCRIPTION
For some reason, the data storage is not working with the default PVC and StorageClass. Falling back to emptyDir, is enough for the tests

Ticket: None
Changelog: None