### PR TITLE
ci: using the right previous lts tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -328,14 +328,14 @@ test:helm_chart_upgrade_from_previous_lts_to_current_lts:
   script:
     - tests/ci-make-deps.sh
     - |
-      echo "INFO - installing mender tag ${MENDER_PREVIOUS_LTS_RELEASE_TAG:-mender-3.6.6} with helm chart version ${MENDER_LTS_HELM_VERSION:-5.11.0}"
+      echo "INFO - installing mender tag ${MENDER_PREVIOUS_LTS_RELEASE_TAG:-mender-3.6.5} with helm chart version ${MENDER_LTS_HELM_VERSION:-5.11.0}"
       source ./tests/variables.sh
       helm upgrade -i mender \
         -f tests/keys.yaml \
         -f tests/values-helmci-5.x.yaml \
         --wait \
         --timeout=${HELM_UPGRADE_TIMEOUT:-15m} \
-        --set global.image.tag="${MENDER_PREVIOUS_LTS_RELEASE_TAG:-mender-3.6.6}" \
+        --set global.image.tag="${MENDER_PREVIOUS_LTS_RELEASE_TAG:-mender-3.6.5}" \
         --set global.image.username=${REGISTRY_MENDER_IO_USERNAME} \
         --set global.image.password="${REGISTRY_MENDER_IO_PASSWORD}" \
         --set global.s3.AWS_ACCESS_KEY_ID="${SEAWEEDFS_ACCESS_KEY_ID}" \


### PR DESCRIPTION
The previous LTS tag was 3.6.5, not 3.6.6

Changelog: None
Ticket: None