### PR TITLE
Add http timeouts and only apply https timeouts when https is enabled

### DIFF
--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -85,13 +85,16 @@ spec:
 {{- end }}
 {{- if .Values.api_gateway.httpPort }}
             - --entrypoints.http.address=:{{- .Values.api_gateway.httpPort }}
+            - --entryPoints.http.transport.respondingTimeouts.idleTimeout=7200
+            - --entryPoints.http.transport.respondingTimeouts.readTimeout=7200
+            - --entryPoints.http.transport.respondingTimeouts.writeTimeout=7200
 {{- end }}
 {{- if .Values.api_gateway.httpsPort }}
             - --entrypoints.https.address=:{{- .Values.api_gateway.httpsPort }}
-{{- end }}
             - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
             - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
+{{- end }}
             - --metrics=true
             - --metrics.prometheus=true
             - --metrics.prometheus.buckets=0.100000,0.300000,1.200000,5.000000


### PR DESCRIPTION
In commit 9654235292dfeeeb0d1f9d203e5faffc5b9ed230 the https port was made optional, but the timeouts for https are still set regardless. This changes that.

This PR also adds timeouts for http, because those were missing and our artifact uploads going via nginx->api_gateway were failing after 60s.