### PR TITLE
ci: run release-please on maintenance branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -675,7 +675,7 @@ cleanup_eks_cluster:failed:manual:
   <<: *eks_cleanup
 
 changelog:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
   stage: changelog
   variables:
     GIT_DEPTH: 0  # Always get the full history
@@ -689,22 +689,12 @@ changelog:
       when: never
     - if: '$RUN_PLAYGROUND == "true"'
       when: never
-    - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
+    # Only run for protected branches (main and maintenance branches)
+    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
   before_script:
-    # install release-please
-    - npm install -g release-please
-    # install github-cli
-    - mkdir -p -m 755 /etc/apt/keyrings
-    - wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
-    - chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-    - apt update
-    - apt install gh jq -y
     # setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
     - git config --global user.name "${GITHUB_USER_NAME}"
-    - npm install -g git-cliff
     # GITHUB_TOKEN for Github cli authentication
     - export GITHUB_TOKEN=${GITHUB_CLI_TOKEN}
   script:
@@ -734,8 +724,8 @@ changelog:
     - git remote remove github-${CI_JOB_ID}
 
 release:github:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
-  stage: release
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+  stage: .post
   tags:
     - hetzner-amd-beefy
   rules:
@@ -743,10 +733,11 @@ release:github:
       when: never
     - if: '$RUN_PLAYGROUND == "true"'
       when: never
-    - if: $CI_COMMIT_BRANCH =~ "/^\d+\.\d+\.x$/" && $RUN_RELEASE == "true"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH && $RUN_RELEASE == "true"
+    # Only make available for protected branches (main and maintenance branches)
+    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
+      when: manual
+      allow_failure: true
   script:
-    - npm install -g release-please
     - release-please github-release
         --token=${GITHUB_BOT_TOKEN_REPO_FULL}
         --repo-url=${GITHUB_REPO_URL}


### PR DESCRIPTION
With these changes you can run release-please and git cliff on any protected (maintenance) branch. Moreover, switching to pre-baked release-please image

Changelog: None