### PR TITLE
fix: Invalid regexp in default value storage_proxy.customRule

### DIFF
--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -243,7 +243,7 @@ api_gateway:
   storage_proxy:
     enabled: false
     url: ""
-    customRule: "HostRegexp(`{domain:^artifacts.*$}`)"
+    customRule: "HostRegexp(`^artifacts.*$`)"
     passHostHeader: false
   compression: true
   security_redirect: null


### PR DESCRIPTION
The expression is using the former Traefik v2 regexp syntax.

Changelog: Title
Ticket: MEN-7741