### PR TITLE
feat: added mongodb secret override

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ The following table lists the parameters for the `deployments` component and the
 | `deployments.probesOverrides.timeoutSeconds` | Override the `timeoutSeconds` for every Readiness and Liveness probes. | `nil` |
 | `deployments.probesOverrides.successThreshold` | Override the `successThreshold` for every Readiness and Liveness probes. | `nil` |
 | `deployments.probesOverrides.failureThreshold` | Override the `failureThreshold` for every Readiness and Liveness probes. | `nil` |
+| `deployments.mongodbExistingSecret` | Use a different MongoDB secret for this service | `nil` |
 
 ### Parameters: device-auth
 

--- a/mender/templates/deployments/_podtemplate.yaml
+++ b/mender/templates/deployments/_podtemplate.yaml
@@ -115,7 +115,11 @@ spec:
     envFrom:
     - prefix: DEPLOYMENTS_
       secretRef:
+      {{- if .dot.Values.deployments.mongodbExistingSecret }}
+        name: {{ .dot.Values.deployments.mongodbExistingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
+      {{- else }}
         name: {{ .dot.Values.global.mongodb.existingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
+      {{- end }}
     {{- if (not .migration) }}
     - prefix: DEPLOYMENTS_
       secretRef:

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -306,6 +306,7 @@ deployments:
   enabled: true
   podAnnotations: {}
   automigrate: true
+  mongodbExistingSecret: ""
   replicas: 1
   resources:
     limits:


### PR DESCRIPTION
With this override, you can choose a different secret for the deployments service, for example a secondary connection or a admin connection

Ticket: MEN-6493