### PR TITLE
chore: cleanup wrong keys

### DIFF
--- a/mender/values-staging.yaml
+++ b/mender/values-staging.yaml
@@ -68,19 +68,3 @@ gui:
     tag: "main@sha256:68b99a1b9c1627c50295c0a67752da9f2da1b46914b5b2719f7a37490a416910"
     registry: docker.io
     repository: mendersoftware
-iot-manager:
-  image:
-    registry: 175683096866.dkr.ecr.us-east-1.amazonaws.com
-    repository: mender-server-enterprise
-create-artifact-worker:
-  image:
-    registry: 175683096866.dkr.ecr.us-east-1.amazonaws.com
-    repository: mender-server-enterprise
-generate-delta-worker:
-  image:
-    registry: 175683096866.dkr.ecr.us-east-1.amazonaws.com
-    repository: mender-server-enterprise
-deviceauth:
-  image:
-    registry: 175683096866.dkr.ecr.us-east-1.amazonaws.com
-    repository: mender-server-enterprise


### PR DESCRIPTION
These keys have been introduced by a faulty automation

Ticket: None
Changelog: None