### PR TITLE
fix: Use more sensible defaults when storage proxy is enabled

### DIFF
--- a/mender/templates/deployments/_podtemplate.yaml
+++ b/mender/templates/deployments/_podtemplate.yaml
@@ -98,7 +98,10 @@ spec:
       value: "true"
     {{- end }}
     {{- end }}
-
+    {{- if .dot.Values.api_gateway.storage_proxy.enabled }}
+    - name: DEPLOYMENTS_STORAGE_PROXY_URI
+      value: {{ printf "%q" .dot.Values.global.url }}
+    {{- end }}
     {{- if .dot.Values.global.enterprise }}
     {{- if not .dot.Values.global.redis.existingSecret }}
     - name: DEPLOYMENTS_REDIS_CONNECTION_STRING

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -365,9 +365,7 @@ deployments:
   #     memory: 64Mi
 
   # custom envs
-  customEnvs:
-    - name: DEPLOYMENTS_STORAGE_PROXY_URI
-      value: "mender.example.com"
+  # customEnvs:
   # - name: LOG_LEVEL
   #   value: DEBUG
 


### PR DESCRIPTION
Set storage.proxy_uri setting in deployments to the public URL {{.Values.global.url}}.

Changelog: Title
Ticket: MC-7739