### PR TITLE
fix: Use sample global.url to avoid confusion

### DIFF
--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -40,7 +40,7 @@ global:
     SMTP_USERNAME: "null"
     SMTP_PASSWORD: "null"
     SMTP_SSL: "false"
-  url: "https://mender-api-gateway"
+  url: "https://mender.example.com"
   # guardrails for subcharts
   namespaceOverride: ""
 


### PR DESCRIPTION
Set default .Values.global.url to the sample public URL to avoid confusion.

Changelog: Title
Ticket: MC-7739

Follow up from: https://github.com/mendersoftware/mender-helm/pull/414/files