### PR TITLE
Add missing internal addresses and replace values

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,6 @@ The following table lists the parameters for the `tenantadm` component and their
 | `tenantadm.service.nodePort` | Node port for the service | `nil` |
 | `tenantadm.env.TENANTADM_MIDDLEWARE` | Set the TENANTADM_MIDDLEWARE variable | `prod` |
 | `tenantadm.env.TENANTADM_SERVER_PRIV_KEY_PATH` | Set the TENANTADM_SERVER_PRIV_KEY_PATH variable | `/etc/tenantadm/rsa/private.pem` |
-| `tenantadm.env.TENANTADM_ORCHESTRATOR_ADDR` | Set the TENANTADM_ORCHESTRATOR_ADDR variable | `http://mender-workflows-server:8080/` |
 | `tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY` | Set the TENANTADM_RECAPTCHA_URL_VERIFY variable | `https://www.google.com/recaptcha/api/siteverify` |
 | `tenantadm.env.TENANTADM_DEFAULT_API_LIMITS` | Set the TENANTADM_DEFAULT_API_LIMITS variable, defining the default rate limits | see below for the default values |
 | `tenantadm.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ The following table lists the parameters for the `iot-manager` component and the
 | `iot_manager.resources.limits.memory` | Resources memory limit | `128Mi` |
 | `iot_manager.resources.requests.cpu` | Resources CPU request | `50m` |
 | `iot_manager.resources.requests.memory` | Resources memory request | `128Mi` |
-| `iot_manager.service.name` | Name of the service | `mender-iot_manager` |
+| `iot_manager.service.name` | Name of the service | `mender-iot-manager` |
 | `iot_manager.service.annotations` | Annotations map for the service | `{}` |
 | `iot_manager.service.type` | Service type | `ClusterIP` |
 | `iot_manager.service.loadBalancerIP` | Service load balancer IP | `nil` |

--- a/README.md
+++ b/README.md
@@ -416,8 +416,6 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `device_auth.service.port` | Port for the service | `8080` |
 | `device_auth.service.nodePort` | Node port for the service | `nil` |
-| `device_auth.env.DEVICEAUTH_INVENTORY_ADDR` | Set the DEVICEAUTH_INVENTORY_ADDR variable | `http://mender-inventory:8080/` |
-| `device_auth.env.DEVICEAUTH_ORCHESTRATOR_ADDR` | Set the DEVICEAUTH_ORCHESTRATOR_ADDR variable | `http://mender-workflows-server:8080` |
 | `device_auth.env.DEVICEAUTH_JWT_ISSUER` | Set the DEVICEAUTH_JWT_ISSUER variable | `Mender` |
 | `device_auth.env.DEVICEAUTH_JWT_EXP_TIMEOUT` | Set the DEVICEAUTH_JWT_EXP_TIMEOUT variable | `604800` |
 | `device_auth.env.DEVICEAUTH_MIDDLEWARE` | Set the DEVICEAUTH_MIDDLEWARE variable | `prod` |
@@ -425,7 +423,6 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.env.DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC` | Set the DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `device_auth.env.DEVICEAUTH_REDIS_DB` | Set the DEVICEAUTH_REDIS_DB variable **[Deprecated from 3.7.0]** | `1` |
 | `device_auth.env.DEVICEAUTH_REDIS_TIMEOUT_SEC` | Set the DEVICEAUTH_REDIS_TIMEOUT_SEC variable **[Deprecated from 3.7.0]** | `1` |
-| `device_auth.env.DEVICEAUTH_TENANTADM_ADDR` | Set the DEVICEAUTH_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
 | `device_auth.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `device_auth.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
 | `device_auth.podSecurityContext.runAsUser` | User ID for the pod | `65534` |
@@ -685,7 +682,6 @@ The following table lists the parameters for the `useradm` component and their d
 | `useradm.env.USERADM_REDIS_LIMITS_EXPIRE_SEC` | Set the USERADM_REDIS_LIMITS_EXPIRE_SEC variable | `3600` |
 | `useradm.env.USERADM_REDIS_DB` | Set the USERADM_REDIS_DB variable **[Deprecated from 3.7.0]** | `2` |
 | `useradm.env.USERADM_REDIS_TIMEOUT_SEC` | Set the USERADM_REDIS_TIMEOUT_SEC variable **[Deprecated from 3.7.0]** | `1` |
-| `useradm.env.USERADM_TENANTADM_ADDR` | Set the USERADM_TENANTADM_ADDR variable | `http://mender-tenantadm:8080` |
 | `useradm.env.USERADM_TOTP_ISSUER` | Set the USERADM_TOTP_ISSUER variable | `Mender` |
 | `useradm.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `useradm.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
@@ -1013,8 +1009,6 @@ The following table lists the parameters for the `devicemonitor` component and t
 | `devicemonitor.service.loadBalancerSourceRanges` | Service load balancer source ranges | `nil` |
 | `devicemonitor.service.port` | Port for the service | `8080` |
 | `devicemonitor.service.nodePort` | Node port for the service | `nil` |
-| `devicemonitor.env.DEVICEMONITOR_USERADM_URL` | Set the DEVICEMONITOR_USERADM_URL variable | `http://mender-useradm:8080/` |
-| `devicemonitor.env.DEVICEMONITOR_WORKFLOWS_URL` | Set the DEVICEMONITOR_WORKFLOWS_URL variable | `http://mender-workflows-server:8080` |
 | `devicemonitor.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `devicemonitor.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
 | `devicemonitor.podSecurityContext.runAsUser` | User ID for the pod | `65534` |

--- a/mender/templates/auditlogs/_podtemplate.yaml
+++ b/mender/templates/auditlogs/_podtemplate.yaml
@@ -73,6 +73,10 @@ spec:
     env:
     - name: AUDITLOGS_AUDITLOG_EXPIRE_SECONDS
       value: {{ .dot.Values.auditlogs.logRetentionSeconds | int | toString | quote }}
+    - name: AUDITLOGS_USERADM_ADDRESS
+      value: {{ printf "http://%s:%d" .dot.Values.useradm.service.name }}
+    - name: AUDITLOGS_DEVICEAUTH_ADDRESS
+      value: {{ printf "http://%s:%d" .dot.Values.deviceauth.service.name }}
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.auditlogs) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
     # Supported configuration settings: https://github.com/mendersoftware/auditlogs/blob/master/config.yaml
     # Set in order, last value for the key will be used in case duplications.

--- a/mender/templates/deployments/_podtemplate.yaml
+++ b/mender/templates/deployments/_podtemplate.yaml
@@ -77,7 +77,8 @@ spec:
     env:
     - name: DEPLOYMENTS_STORAGE_DEFAULT
       value: {{ .dot.Values.global.storage | quote }}
-
+    - name: DEPLOYMENTS_INVENTORY_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.inventory.service.name .dot.Values.inventory.service.port }}
     - name: DEPLOYMENTS_MIDDLEWARE
       value: {{ .dot.Values.deployments.env.DEPLOYMENTS_MIDDLEWARE | quote }}
     - name: DEPLOYMENTS_AWS_TAG_ARTIFACT

--- a/mender/templates/device-auth/_podtemplate.yaml
+++ b/mender/templates/device-auth/_podtemplate.yaml
@@ -81,11 +81,13 @@ spec:
 
     env:
     - name: DEVICEAUTH_INVENTORY_ADDR
-      value: {{ .dot.Values.device_auth.env.DEVICEAUTH_INVENTORY_ADDR | quote }}
+      value: {{ printf "http://%s:%d" .dot.Values.inventory.service.name .dot.Values.inventory.service.port }}
+    - name: DEVICEAUTH_IOT_MANAGER_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.iot_manager.service.name .dot.Values.iot_manager.service.port }}
+    - name: DEVICEAUTH_ORCHESTRATOR_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port }}
     - name: DEVICEAUTH_SERVER_PRIV_KEY_PATH
       value: /etc/deviceauth/rsa/private.pem
-    - name: DEVICEAUTH_ORCHESTRATOR_ADDR
-      value: {{ .dot.Values.device_auth.env.DEVICEAUTH_ORCHESTRATOR_ADDR | quote }}
     - name: DEVICEAUTH_JWT_ISSUER
       value: {{ .dot.Values.device_auth.env.DEVICEAUTH_JWT_ISSUER | quote }}
     - name: DEVICEAUTH_JWT_EXP_TIMEOUT
@@ -96,7 +98,7 @@ spec:
     - name: DEVICEAUTH_HAVE_ADDONS
       value: "true"
     - name: DEVICEAUTH_TENANTADM_ADDR
-      value: {{ .dot.Values.device_auth.env.DEVICEAUTH_TENANTADM_ADDR | quote }}
+      value: {{ printf "http://%s:%d" .dot.Values.tenantadm.service.name .dot.Values.tenantadm.service.port }}
     {{- end }}
     # Enable audit logging
     {{- if and .dot.Values.auditlogs.enabled .dot.Values.global.enterprise }}

--- a/mender/templates/deviceconfig/_podtemplate.yaml
+++ b/mender/templates/deviceconfig/_podtemplate.yaml
@@ -79,7 +79,7 @@ spec:
     {{- end }}
     # Workflows orchestrator address
     - name: DEVICECONFIG_WORKFLOWS_URL
-      value: http://mender-workflows-server:8080/
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.deviceconfig) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
 
     # Supported configuration settings: https://github.com/mendersoftware/deviceconfig/blob/master/config.yaml

--- a/mender/templates/deviceconnect/_podtemplate.yaml
+++ b/mender/templates/deviceconnect/_podtemplate.yaml
@@ -93,7 +93,7 @@ spec:
 
     # Workflows orchestrator address
     - name: DEVICECONNECT_WORKFLOWS_URL
-      value: http://mender-workflows-server:8080/
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
 
     - name: DEVICECONNECT_WS_ALLOWED_ORIGINS
       value: >-

--- a/mender/templates/devicemonitor/_podtemplate.yaml
+++ b/mender/templates/devicemonitor/_podtemplate.yaml
@@ -71,13 +71,12 @@ spec:
     {{- end }}
 
     env:
-    # Workflows orchestrator address
-    - name: DEVICEMONITOR_USERADM_URL
-      value: {{ .dot.Values.devicemonitor.env.DEVICEMONITOR_USERADM_URL | quote }}
-
-    # Workflows orchestrator address
+    - name: DEVICEMONITOR_INVENTORY_URL
+      value: {{ printf "http://%s:%d" .dot.Values.inventory.service.name .dot.Values.inventory.service.port | quote }}
+    - name: DEVICEMONITOR_USERADM_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.useradm.service.name .dot.Values.useradm.service.port | quote }}
     - name: DEVICEMONITOR_WORKFLOWS_URL
-      value: {{ .dot.Values.devicemonitor.env.DEVICEMONITOR_WORKFLOWS_URL | quote }}
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
 
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.devicemonitor) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
 

--- a/mender/templates/inventory/_podtemplate.yaml
+++ b/mender/templates/inventory/_podtemplate.yaml
@@ -72,6 +72,10 @@ spec:
     {{- end }}
 
     env:
+    - name: INVENTORY_DEVICEMONITOR_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.devicemonitor.service.name .dot.Values.devicemonitor.service.port | quote }}
+    - name: INVENTORY_ORCHESTRATOR_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
     - name: INVENTORY_MIDDLEWARE
       value: {{ .dot.Values.inventory.env.INVENTORY_MIDDLEWARE | quote }}
     {{- if and .dot.Values.global.enterprise }}

--- a/mender/templates/iot-manager/_podtemplate.yaml
+++ b/mender/templates/iot-manager/_podtemplate.yaml
@@ -71,6 +71,8 @@ spec:
     {{- end }}
 
     env:
+    - name: IOT_MANAGER_DEVICEAUTH_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.device_auth.service.name .dot.Values.device_auth.service.port | quote }}
     - name: IOT_MANAGER_NATS_URI
     {{- if .dot.Values.global.nats.existingSecret }}
       valueFrom:

--- a/mender/templates/tenantadm/_podtemplate.yaml
+++ b/mender/templates/tenantadm/_podtemplate.yaml
@@ -82,8 +82,14 @@ spec:
       value: {{ .dot.Values.tenantadm.env.TENANTADM_MIDDLEWARE | quote }}
     - name: TENANTADM_SERVER_PRIV_KEY_PATH
       value: {{ .dot.Values.tenantadm.env.TENANTADM_SERVER_PRIV_KEY_PATH | quote }}
+    - name: TENANTADM_DEPLOYMENTS_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.deployments.service.name .dot.Values.deployments.service.port | quote }}
+    - name: TENANTADM_DEVICEAUTH_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.device_auth.service.name .dot.Values.device_auth.service.port | quote }}
     - name: TENANTADM_ORCHESTRATOR_ADDR
-      value: {{ .dot.Values.tenantadm.env.TENANTADM_ORCHESTRATOR_ADDR | quote }}
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
+    - name: TENANTADM_USERADM_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.useradm.service.name .dot.Values.useradm.service.port | quote }}
     - name: TENANTADM_RECAPTCHA_URL_VERIFY
       value: {{ .dot.Values.tenantadm.env.TENANTADM_RECAPTCHA_URL_VERIFY | quote }}
     - name: TENANTADM_DEFAULT_API_LIMITS

--- a/mender/templates/useradm/_podtemplate.yaml
+++ b/mender/templates/useradm/_podtemplate.yaml
@@ -79,6 +79,10 @@ spec:
     {{- end }}
 
     env:
+    - name: USERADM_INVENTORY_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.inventory.service.name .dot.Values.inventory.service.port | quote }}
+    - name: USERADM_ORCHESTRATOR_ADDR
+      value: {{ printf "http://%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
     - name: USERADM_MIDDLEWARE
       value: {{ .dot.Values.useradm.env.USERADM_MIDDLEWARE | quote }}
     - name: USERADM_PROXY_COUNT
@@ -95,7 +99,7 @@ spec:
     - name: USERADM_HAVE_ADDONS
       value: "true"
     - name: USERADM_TENANTADM_ADDR
-      value: {{ .dot.Values.useradm.env.USERADM_TENANTADM_ADDR | quote }}
+      value: {{ printf "http://%s:%d" .dot.Values.tenantadm.service.name .dot.Values.tenantadm.service.port | quote }}
     {{- end }}
     - name: USERADM_TOTP_ISSUER
       value: {{ .dot.Values.useradm.env.USERADM_TOTP_ISSUER | quote }}

--- a/mender/templates/workflows/_podtemplate.yaml
+++ b/mender/templates/workflows/_podtemplate.yaml
@@ -78,6 +78,28 @@ spec:
 
     env:
     # NATS uri
+    - name: AUDITLOGS_ADDR
+      value: {{ printf "%s:%d" .dot.Values.auditlogs.service.name .dot.Values.auditlogs.service.port }}
+    - name: DEPLOYMENTS_ADDR
+      value: {{ printf "%s:%d" .dot.Values.deployments.service.name .dot.Values.deployments.service.port }}
+    - name: DEVICEAUTH_ADDR
+      value: {{ printf "%s:%d" .dot.Values.device_auth.service.name .dot.Values.device_auth.service.port }}
+    - name: DEVICECONFIG_ADDR
+      value: {{ printf "%s:%d" .dot.Values.deviceconfig.service.name .dot.Values.deviceconfig.service.port }}
+    - name: DEVICECONNECT_ADDR
+      value: {{ printf "%s:%d" .dot.Values.deviceconnect.service.name .dot.Values.deviceconnect.service.port }}
+    - name: DEVICEMONITOR_ADDR
+      value: {{ printf "%s:%d" .dot.Values.devicemonitor.service.name .dot.Values.devicemonitor.service.port }}
+    - name: INVENTORY_ADDR
+      value: {{ printf "%s:%d" .dot.Values.inventory.service.name .dot.Values.inventory.service.port }}
+    - name: IOT_MANAGER_ADDR
+      value: {{ printf "%s:%d" .dot.Values.iot_manager.service.name .dot.Values.iot_manager.service.port }}
+    - name: TENANTADM_ADDR
+      value: {{ printf "%s:%d" .dot.Values.tenantadm.service.name .dot.Values.tenantadm.service.port }}
+    - name: USERADM_ADDR
+      value: {{ printf "%s:%d" .dot.Values.useradm.service.name .dot.Values.useradm.service.port }}
+    - name: WORKFLOWS_SERVER_ADDR
+      value: {{ printf "%s:%d" .dot.Values.workflows.service.name .dot.Values.workflows.service.port }}
     - name: WORKFLOWS_NATS_URI
     {{- if .dot.Values.global.nats.existingSecret }}
       valueFrom:

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -681,7 +681,6 @@ tenantadm:
     TENANTADM_DEFAULT_API_LIMITS: '{"management":{"bursts":[],"quota":{"max_calls":600,"interval_sec":60}},"devices":{"bursts":[{"action":"POST","uri":"/api/devices/v1/authentication","min_interval_sec":5},{"action":"GET","uri":"/api/devices/v1/deployments/device/deployments/next","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/deployments/device/deployments/next","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v2/deployments/device/deployments/next","min_interval_sec":5},{"action":"GET","uri":"/api/devices/v1/deviceconfig/configuration","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/deviceconfig/configuration","min_interval_sec":5},{"action":"PATCH","uri":"/api/devices/v1/inventory/device/attributes","min_interval_sec":5},{"action":"PUT","uri":"/api/devices/v1/inventory/device/attributes","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/devicemonitor/alert","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/devicemonitor/alert","min_interval_sec":5},{"action":"POST","uri":"/api/devices/v1/devicemonitor/config","min_interval_sec":5}],"quota":{"max_calls":60,"interval_sec":60}}}'
     TENANTADM_MIDDLEWARE: prod
     TENANTADM_SERVER_PRIV_KEY_PATH: /etc/tenantadm/rsa/private.pem
-    TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
     TENANTADM_RECAPTCHA_URL_VERIFY: https://www.google.com/recaptcha/api/siteverify
   podSecurityContext:
     enabled: false

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -408,15 +408,12 @@ device_auth:
     type: ClusterIP
     port: 8080
   env:
-    DEVICEAUTH_INVENTORY_ADDR: http://mender-inventory:8080/
-    DEVICEAUTH_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
     DEVICEAUTH_JWT_ISSUER: Mender
     DEVICEAUTH_JWT_EXP_TIMEOUT: 604800
     DEVICEAUTH_MIDDLEWARE: prod
     DEVICEAUTH_REDIS_DB: "1"
     DEVICEAUTH_REDIS_TIMEOUT_SEC: "1"
     DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC: "3600"
-    DEVICEAUTH_TENANTADM_ADDR: http://mender-tenantadm:8080
   podSecurityContext:
     enabled: false
     runAsNonRoot: true
@@ -767,7 +764,6 @@ useradm:
     USERADM_REDIS_DB: "1"
     USERADM_REDIS_TIMEOUT_SEC: "1"
     USERADM_REDIS_LIMITS_EXPIRE_SEC: "3600"
-    USERADM_TENANTADM_ADDR: http://mender-tenantadm:8080
     USERADM_TOTP_ISSUER: Mender
   podSecurityContext:
     enabled: false
@@ -1270,9 +1266,6 @@ devicemonitor:
     annotations: {}
     type: ClusterIP
     port: 8080
-  env:
-    DEVICEMONITOR_USERADM_URL: http://mender-useradm:8080/
-    DEVICEMONITOR_WORKFLOWS_URL: http://mender-workflows-server:8080/
   podSecurityContext:
     enabled: false
     runAsNonRoot: true


### PR DESCRIPTION
Extension of #417.

The internal addresses are uniquely determined from the name and port of
the respective service. They should not be configurable. The following
values have been removed and will be ineffectual:
- `device_auth.env.DEVICEAUTH_INVENTORY_ADDR`
- `device_auth.env.DEVICEAUTH_ORCHESTRATOR_ADDR`
- `device_auth.env.DEVICEAUTH_TENANTADM_ADDR`
- `useradm.env.USERADM_TENANTADM_ADDR`
- `devicemonitor.env.DEVICEMONITOR_USERADM_URL`
- `devicemonitor.env.DEVICEMONITOR_WORKFLOWS_URL`