### PR TITLE
ci: switch to stable release for real

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
     }
   },
   "release-type": "helm",
-  "versioning": "prerelease",
+  "versioning": "default",
   "prerelease": false,
   "prerelease-type": "rc",
   "include-component-in-tag": true,


### PR DESCRIPTION
The versioning key should be flipped to default, out of prerelease, to make actual stable releases every time, instead of prereleases.

Ticket: None