### PR TITLE
Optionals deviceauth cronjobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ The following table lists the parameters for the `device-auth` component and the
 | `device_auth.probesOverrides.successThreshold` | Override the `successThreshold` for every Readiness and Liveness probes. | `nil` |
 | `device_auth.probesOverrides.timeoutSeconds` | Override the `timeoutSeconds` for every Readiness and Liveness probes. | `nil` |
 | `device_auth.probesOverrides.failureThreshold` | Override the `failureThreshold` for every Readiness and Liveness probes. | `nil` |
+| `device_auth.cronjobs.enabled` | Enable optional maintenance cronjobs | `false` |
+| `device_auth.cronjobs.jobs` | List of optional maintenance cronjobs | `nil` |
 
 ### Parameters: gui
 

--- a/mender/templates/device-auth/cronjob_license_count.yaml
+++ b/mender/templates/device-auth/cronjob_license_count.yaml
@@ -35,7 +35,7 @@ spec:
           - name: device-auth-license-count
             image: {{ include "mender.image" $context }}
             imagePullPolicy: {{ include "mender.imagePullPolicy" $context }}
-            command: ["/usr/bin/deviceauth-enterprise", "license-count"]
+            command: ["/usr/bin/deviceauth", "license-count"]
 
             envFrom:
             - prefix: DEVICEAUTH_

--- a/mender/templates/device-auth/cronjobs.yaml
+++ b/mender/templates/device-auth/cronjobs.yaml
@@ -1,0 +1,75 @@
+{{- if and (.Values.device_auth.enabled) (.Values.device_auth.cronjobs.enabled) }}
+{{- $context := (dict "dot" .
+                      "component" "device-auth"
+                      "imageComponent" "deviceauth"
+                      "override" .Values.device_auth) -}}
+{{- range $index, $job := .Values.device_auth.cronjobs.jobs }}
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "mender.fullname" $ }}-{{ $job.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "mender.labels" $ | nindent 4 -}}
+    app.kubernetes.io/name: {{ include "mender.fullname" $ }}-{{ $job.name }}
+    app.kubernetes.io/component: device_auth
+spec:
+  schedule: {{ $job.schedule | quote }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit | default "1" }}
+  successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit | default "1" }}
+  suspend: {{ $job.suspend | default "false" }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ $job.name }}
+            image: {{ include "mender.image" $context }}
+            imagePullPolicy: {{ include "mender.imagePullPolicy" $context }}
+            {{- with $job.command }}
+            command:
+{{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $job.args }}
+            args:
+{{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $job.customEnvs }}
+            env:
+{{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $job.customEnvFroms }}
+            envFrom:
+{{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $job.resources }}
+            resources:
+{{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- with $job.tolerations }}
+          tolerations:
+{{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $job.affinity }}
+          affinity:
+{{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if and $.Values.global.image $.Values.global.image.username }}
+          imagePullSecrets:
+          - name: "docker-registry"
+          {{- else }}
+          {{- $ips := coalesce $.Values.device_auth.imagePullSecrets $.Values.default.imagePullSecrets  }}
+          {{- if $ips }}
+          imagePullSecrets:
+          {{- toYaml $ips | nindent 10}}
+          {{- end }}
+          {{- end }}
+          {{- with $job.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          restartPolicy: {{ $job.restartPolicy | default "Never" }}
+{{- end }}
+{{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -465,6 +465,35 @@ device_auth:
     # successThreshold: 2
     # failureThreshold: 6
 
+  #
+  # Optional cronjobs for device auth.
+  # These cronjobs are used to perform maintenance tasks, like device licensing
+  #
+  cronjobs:
+    enabled: false
+    jobs: []
+    #   - name: device-auth-license-count
+    #     schedule: "7 3 * * *"
+    #     command: []
+    #     args:
+    #     - "license-count"
+    #     customEnvs:
+    #       - name: DEVICEAUTH_MONGO
+    #         valueFrom:
+    #           secretKeyRef:
+    #             key: MONGO_URL
+    #             name: mongodb-common
+    #     resources:
+    #       limits:
+    #         cpu: 100m
+    #         memory: 100Mi
+    #       requests:
+    #         cpu: 50m
+    #         memory: 50Mi
+    #     tolerations: []
+    #     priorityClassName: "mender-low-priority"
+    #     affinity: {}
+
 # Generate Delta Worker feature
 # Experimental feature, still in beta
 # will be released in the next Mender versions
@@ -1415,5 +1444,7 @@ dbmigration:
 # Feature preview: Device License Count
 # Only available from version 3.6,
 # and available in Mender Enterprise
+# **WARNING**: This will be deprecated in the Helm Chart v7.0.0
+# and will be replaced by the `device_auth.cronjobs` feature.
 device_license_count:
   enabled: false


### PR DESCRIPTION
You can create custom cronjobs based on the deviceauth service. This feature is going to deprecate the device_license_count feature, that could be installed as a custom cronjob, with the provided example in the Values file.
The device_license_count key will be removed in the future.

Ticket: MC-7789