### PR TITLE
Switch api-gateway tls certificate to k8s tls type

### DIFF
--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -547,8 +547,8 @@ data:
 {{- if $isTls }}
     tls:
       certificates:
-        - certFile: /etc/traefik/certs/cert.crt
-          keyFile: /etc/traefik/certs/private.key
+        - certFile: /etc/traefik/certs/tls.crt
+          keyFile: /etc/traefik/certs/tls.key
           stores:
             - default
 {{- end }}

--- a/mender/templates/api-gateway/secret.yaml
+++ b/mender/templates/api-gateway/secret.yaml
@@ -13,12 +13,13 @@ metadata:
     app.kubernetes.io/component: secrets
     app.kubernetes.io/part-of: mender
     helm.sh/chart: "{{ .Chart.Name }}"
+type: kubernetes.io/tls
 data:
   {{- if .Values.api_gateway.certs.cert }}
-  cert.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
+  tls.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
   {{- end }}
   {{- if .Values.api_gateway.certs.key }}
-  private.key: {{ .Values.api_gateway.certs.key | b64enc}}
+  tls.key: {{ .Values.api_gateway.certs.key | b64enc}}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
We currently have nginx sitting in front of the api-gateway, doing SSL termination. It is also doing storage proxying, but we can move that to Traefik now with the latest release 😄 

We use cert-manager for our certificates, and currently we can't pass a secret cert-manager creates into the api-gateway, as it uses the wrong keys.

We prefer not to use k8's ingress, for a couple of reasons, so want to have Traefik serve the traffic directly