### PR TITLE
Don't run R2 tests with non protected branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -527,6 +527,9 @@ test:helm_chart_install_with_r2:
       when: never
     - if: '$RUN_PLAYGROUND == "true"'
       when: never
+    # contains protected variables: never run on non protected branches
+    - if: '$CI_COMMIT_REF_PROTECTED != "true"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-setup-test-r2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -688,8 +688,9 @@ changelog:
     # Don't run release-please on staging and prod branches
     - if: $CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "prod"
       when: never
-    # Only run for protected branches (main and maintenance branches)
-    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
+    # Only run for some protected branches (master and LTS branches)
+    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "5.x"
+      when: always
   before_script:
     # setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
@@ -737,7 +738,7 @@ release:github:
     - if: $CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "prod"
       when: never
     # Only make available for protected branches (main and maintenance branches)
-    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
+    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "5.x"
       when: manual
       allow_failure: true
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -739,7 +739,7 @@ release:github:
       when: never
     # Only make available for protected branches (main and maintenance branches)
     - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "5.x"
-      when: manual
+      when: always
       allow_failure: true
   script:
     - release-please github-release


### PR DESCRIPTION
Cloudflare R2 test is using protected variables; skipping this test when running non protected branches.

Ticket: QA-960