### PR TITLE
Avoid breaking change with featureGates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.certs` | certificate management | `nil` |
 | `api_gateway.certs.cert` | Public certificate (with full chain optionally) in PEM format | `nil` |
 | `api_gateway.certs.key` | Private key in PEM format | `nil` |
-| `api_gateway.certs.existingSecret` | Preexisting secret containing the Cert (key `cert.crt`) and the Key (key `private.key`) | `nil` |
+| `api_gateway.certs.existingSecret` | Preexisting secret containing the Cert (key `cert.crt`) and the Key (key `private.key`). **Deprecation notice**: these keys will be moved to `tls.crt` and `tls.key` respectively in the next releases. If you want to use it in advance, please enable `featureGates.k8sTlsSecrets` | `nil` |
 | `api_gateway.updateStrategy` | The strategy to use to update existing pods | `nil` |
 | `api_gateway.accesslogs` | Traefik Access Logs, enabled by default | `true` |
 | `api_gateway.podMonitor.enabled` | If enabled, creates a PodMonitor resource for scraping Traefik metrics | `false` |
@@ -956,6 +956,17 @@ The following table lists the parameters for the `redis` component and their def
 | `redis.containerSecurityContext.enabled` | Enable container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `redis.containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation for container | `false` |
 | `redis.containerSecurityContext.runAsUser` | User ID for the container | `999` |
+
+### Parameters: featureGates
+
+The special parameter `featureGates` is used to enable specific features
+that are still under development or are going to replace existing ones.
+
+The following table lists the parameters:
+
+| Parameter | Description | Default |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `featureGates.k8sTlsSecrets` | Use K8s TLS Secret type for the API Gateway: `tls.crt` and `tls.key` instead of `cert.crt` and `private.key` | `false` |
 
 ## Create a tenant and a user from command line
 

--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -547,8 +547,13 @@ data:
 {{- if $isTls }}
     tls:
       certificates:
+        {{- if .Values.featureGates.k8sTlsSecrets }}
         - certFile: /etc/traefik/certs/tls.crt
           keyFile: /etc/traefik/certs/tls.key
+        {{- else }}
+        - certFile: /etc/traefik/certs/cert.crt
+          keyFile: /etc/traefik/certs/private.key
+        {{- end }}
           stores:
             - default
 {{- end }}

--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -547,8 +547,8 @@ data:
 {{- if $isTls }}
     tls:
       certificates:
-        - certFile: /etc/traefik/certs/cert.crt
-          keyFile: /etc/traefik/certs/private.key
+        - certFile: /etc/traefik/certs/tls.crt
+          keyFile: /etc/traefik/certs/tls.key
           stores:
             - default
 {{- end }}

--- a/mender/templates/api-gateway/secret.yaml
+++ b/mender/templates/api-gateway/secret.yaml
@@ -13,13 +13,23 @@ metadata:
     app.kubernetes.io/component: secrets
     app.kubernetes.io/part-of: mender
     helm.sh/chart: "{{ .Chart.Name }}"
+{{- if .Values.featureGates.k8sTlsSecrets }}
 type: kubernetes.io/tls
+{{- end }}
 data:
   {{- if .Values.api_gateway.certs.cert }}
+  {{- if .Values.featureGates.k8sTlsSecrets }}
   tls.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
+  {{- else }}
+  cert.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
+  {{- end }}
   {{- end }}
   {{- if .Values.api_gateway.certs.key }}
+  {{- if .Values.featureGates.k8sTlsSecrets }}
   tls.key: {{ .Values.api_gateway.certs.key | b64enc}}
+  {{- else }}
+  private.key: {{ .Values.api_gateway.certs.key | b64enc}}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/mender/templates/api-gateway/secret.yaml
+++ b/mender/templates/api-gateway/secret.yaml
@@ -13,12 +13,13 @@ metadata:
     app.kubernetes.io/component: secrets
     app.kubernetes.io/part-of: mender
     helm.sh/chart: "{{ .Chart.Name }}"
+type: kubernetes.io/tls
 data:
   {{- if .Values.api_gateway.certs.cert }}
-  cert.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
+  tls.crt: {{ .Values.api_gateway.certs.cert | b64enc }}
   {{- end }}
   {{- if .Values.api_gateway.certs.key }}
-  private.key: {{ .Values.api_gateway.certs.key | b64enc}}
+  tls.key: {{ .Values.api_gateway.certs.key | b64enc}}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -1448,3 +1448,10 @@ dbmigration:
 # and will be replaced by the `device_auth.cronjobs` feature.
 device_license_count:
   enabled: false
+
+# Feature preview
+featureGates:
+  # Use K8s TLS Secret type for the API Gateway:
+  # tls.crt and tls.key replace cert.crt and private.key
+  # This affects api_gateway.certs when SSL is enabled
+  k8sTlsSecrets: false


### PR DESCRIPTION
Reintroducing the k8s TLS feature (commit 58687a0a22b809c8c6229f255a981165f8acb4bf) and  introducing the `featureGates.k8sTlsSecrets` option, to make that new feature as optional and avoiding breaking changes when using `api_gateway.certs.existingSecret`