### PR TITLE
fix(deployments): use mongodb secret variable if present

### DIFF
--- a/mender/templates/deployments/cronjob.yaml
+++ b/mender/templates/deployments/cronjob.yaml
@@ -54,7 +54,11 @@ spec:
             envFrom:
             - prefix: DEPLOYMENTS_
               secretRef:
-                name: mongodb-common
+              {{- if .Values.deployments.mongodbExistingSecret }}
+                name: {{ .Values.deployments.mongodbExistingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
+              {{- else }}
+                name: {{ .Values.global.mongodb.existingSecret | default (ternary "mongodb-common" "mongodb-common-prerelease" (empty .migration)) }}
+              {{- end }}
             - prefix: DEPLOYMENTS_
               secretRef:
                 name: {{ .Values.global.s3.existingSecret | default "artifacts-storage" }}


### PR DESCRIPTION
If mongodb secret is configured, cronjob will fail to start with error message `secret "mongodb-common" not found: CreateContainerConfigError`, since the hardcoded secret will be used instead of the configured one.

This should probably have been updated when this PR was submitted: https://github.com/mendersoftware/mender-helm/pull/392

Kubernetes deployment yaml looks like this, which is correct:
```yaml
        ...
        envFrom:
        - prefix: DEPLOYMENTS_
          secretRef:
            name: mender-mongodb-connection-url
        ...
```