### PR TITLE
fix: set ingress namespace explicit

### DIFF
--- a/mender/templates/ingress.yaml
+++ b/mender/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Chart.Name }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mender.labels" . | nindent 4 }}
 {{- with .Values.ingress.annotations }}


### PR DESCRIPTION
When templating the helm chart, the ingress doesn't came with a named namespace. This could be an issue when you apply the manifests generated from the helm template

Ticket: None