### PR TITLE
fix: display Mender Version

### DIFF
--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -103,9 +103,9 @@ spec:
         - name: HAVE_MULTITENANT
           value: {{ .Values.global.enterprise | quote }}
         - name: MENDER_VERSION
-          value: {{ trimPrefix "v" .Chart.AppVersion | quote }}
+          value: {{ trimPrefix "v" (.Values.default.image.tag | default .Chart.AppVersion) | quote }}
         - name: INTEGRATION_VERSION
-          value: {{ trimPrefix "v" .Chart.AppVersion | quote }}
+          value: {{ trimPrefix "v" (.Values.default.image.tag | default .Chart.AppVersion) | quote }}
         {{- end }}
         {{- if and .Values.auditlogs.enabled .Values.global.enterprise }}
         - name: HAVE_AUDITLOGS


### PR DESCRIPTION
Display the actual Mender version based on the computed Tag, not just on Chart.Appversion

Ticket: None