### PR TITLE
fix: some migration jobs don't run for open source

### DIFF
--- a/mender/templates/useradm/job.yaml
+++ b/mender/templates/useradm/job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.enterprise .Values.dbmigration.enable }}
+{{- if .Values.dbmigration.enable }}
 {{- $context := dict "dot" .
                      "component" "useradm"
                      "override" .Values.useradm

--- a/mender/templates/workflows/job.yaml
+++ b/mender/templates/workflows/job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.enterprise .Values.dbmigration.enable }}
+{{- if .Values.dbmigration.enable }}
 {{- $context := dict "dot" .
                      "component" "workflows"
                      "override" .Values.workflows


### PR DESCRIPTION
The migration jobs for the Workflows and Useradm service are not running for the Open Source helm chart by default. This fix enables them.

Ticket: MC-8005