### PR TITLE
feat: Add value ingress.extraPaths.backend.servicePortNumber

### DIFF
--- a/mender/templates/ingress.yaml
+++ b/mender/templates/ingress.yaml
@@ -49,7 +49,11 @@ spec:
               service:
                 name: {{ .backend.serviceName }}
                 port:
+                {{- if .backend.servicePort }}
                   name: {{ .backend.servicePort }}
+                {{- else }}
+                  number: {{ .backend.servicePortNumber }}
+                {{- end }}
           {{- end }}
           - path: {{ $ingressPath }}
             pathType: Prefix


### PR DESCRIPTION
The new parameter allows specifying a numeric port number instead of name to configure additional ingress routes.

Changelog: Commit
Ticket: None