### PR TITLE
chore: Clean up duplicate port name

### DIFF
--- a/mender/templates/gui/service.yaml
+++ b/mender/templates/gui/service.yaml
@@ -33,7 +33,6 @@ spec:
     {{- if .Values.gui.service.nodePort }}
     nodePort: {{ .Values.gui.service.nodePort }}
     {{- end }}
-    name: http
   selector:
     app.kubernetes.io/name: {{ include "mender.fullname" . }}-gui
 {{- end }}


### PR DESCRIPTION
Fixes a regression introduced by 8fc2e846a91da391f08ca7636efaafe1216836f6 for the gui service.