### PR TITLE
fix: avoid useless gui wait start

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ The following table lists the parameters for the `gui` component and their defau
 | `gui.probesOverrides.successThreshold` | Override the `successThreshold` for every Readiness and Liveness probes. | `nil` |
 | `gui.probesOverrides.timeoutSeconds` | Override the `timeoutSeconds` for every Readiness and Liveness probes. | `nil` |
 | `gui.probesOverrides.failureThreshold` | Override the `failureThreshold` for every Readiness and Liveness probes. | `nil` |
+| `gui.probesOverrides.initialDelaySeconds` | Override the `initialDelaySeconds` for every Readiness and Liveness probes. | `2` |
+| `gui.probesOverrides.periodSeconds` | Override the `periodSeconds` for every Readiness and Liveness probes. | `5` |
 | `gui.hpa` | HorizontalPodAutoscaler support | `nil` |
 | `gui.hpa.enabled` | HorizontalPodAutoscaler enabled | `nil` |
 | `gui.hpa.minReplicas` | HorizontalPodAutoscaler minReplicas | `nil` |

--- a/mender/templates/gui/deployment.yaml
+++ b/mender/templates/gui/deployment.yaml
@@ -81,10 +81,6 @@ spec:
         startupProbe:
           tcpSocket:
             port: {{ .Values.gui.httpPort }}
-          # We are executing js minify at container startup. This is expensive and time consuming.
-          # The default for this service is 120
-          initialDelaySeconds: 120
-          periodSeconds: 15
           {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.gui.probesOverrides ) }}
           {{- nindent 10 . }}
           {{- end }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -605,7 +605,8 @@ gui:
 
   # Override the properties of the Readiness, Liveness and Startup probes
   probesOverrides:
-    {}
+    initialDelaySeconds: 2
+    periodSeconds: 5
     # timeoutSeconds: 2
     # successThreshold: 2
     # failureThreshold: 6


### PR DESCRIPTION
The gui container used to have a js minify build which has been refactored long ago and this waiting time is a leftover. Removing it.

Ticket: MC-8006