### PR TITLE
api-gateway: add deployment annotations to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.image.imagePullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `api_gateway.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
 | `api_gateway.nodeSelector` | [Node selection](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) | `{}` |
+| `api_gateway.deploymentAnnotations` | add custom deployment annotations | `nil` |
 | `api_gateway.podAnnotations` | add custom pod annotations | `nil` |
 | `api_gateway.replicas` | Number of replicas | `1` |
 | `api_gateway.affinity` | [Affinity map](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for the POD | `{}` |

--- a/mender/templates/api-gateway/deployment.yaml
+++ b/mender/templates/api-gateway/deployment.yaml
@@ -22,6 +22,10 @@ metadata:
     {{- include "mender.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "mender.fullname" . }}-api-gateway
     app.kubernetes.io/component: api-gateway
+  {{- with .Values.api_gateway.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (or .Values.api_gateway.hpa .Values.default.hpa) }}
   replicas: {{ .Values.api_gateway.replicas }}

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -212,6 +212,7 @@ nats:
 
 api_gateway:
   enabled: true
+  deploymentAnnotations: {}
   podAnnotations: {}
   dashboard: false
   image:


### PR DESCRIPTION
We have a service that auto-reloads deployments when secrets/configmaps change (i.e cert-manager renews a certificate). See https://github.com/stakater/Reloader

We need to be able to set annotations on the api-gateway to support this, so I've added this into the template.

For completeness, if I add this to the api-gateway should I go through and add this option to all other k8s deployment templates?