### PR TITLE
fix: mongodb poddistruptionbudget

### DIFF
--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -170,7 +170,6 @@ mongodb:
   # replicas.
   pdb:
     enabled: true
-    minAvailable: 2
     maxUnavailable: 1
   auth:
     enabled: true


### PR DESCRIPTION
Don't specify both maxUnavailable and minAvailable which collide in a PodDisruptionBudget resource. By default only minAvailable: 1 is kept within the internal MongoDB.

Ticket: MC-8043