### PR TITLE
fix: correctly display x-mender headers

### DIFF
--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -506,8 +506,8 @@ data:
             browserXssFilter: true
             customRequestHeaders:
               "X-Forwarded-Proto": "{{ $scheme }}"
-              "X-Mender-Version": "{{ .Chart.Version }}"
-              "X-Mender-Chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+              "x-mender-version": "{{ .Chart.Version }}"
+              "x-mender-chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
 
         compression:
 {{- if .Values.api_gateway.compression }}


### PR DESCRIPTION
Ticket: MC-6867

Tentative fix to display the currently missing headers `X-Mender-Version` and `X-Mender-Chart`