### PR TITLE
fix: x-mender headers to customResponseHeaders

### DIFF
--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -505,9 +505,10 @@ data:
             contentTypeNosniff: true
             browserXssFilter: true
             customRequestHeaders:
-              "X-Forwarded-Proto": "{{ $scheme }}"
-              "x-mender-version": "{{ .Chart.Version }}"
-              "x-mender-chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+              X-Forwarded-Proto: "{{ $scheme }}"
+            customResponseHeaders:
+              x-mender-version: "{{ .Chart.Version }}"
+              x-mender-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 
         compression:
 {{- if .Values.api_gateway.compression }}


### PR DESCRIPTION
To correctly expose the custom x-mender headers, we have to set them in the customResponseHeaders, instead of in the customRequestHeaders, which is for client to server communication only.

Ticket: MC-6867