### PR TITLE
MEN-5159: Set HAVE_DEVICEMONITOR env variable in workflows

### DIFF
--- a/mender/templates/workflows/_podtemplate.yaml
+++ b/mender/templates/workflows/_podtemplate.yaml
@@ -125,6 +125,10 @@ spec:
     - name: HAVE_DEVICECONFIG
       value: "true"
     {{- end }}
+    {{- if .dot.Values.devicemonitor.enabled }}
+    - name: HAVE_DEVICEMONITOR
+      value: "true"
+    {{- end }}
     {{- end }}
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.workflows) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
 


### PR DESCRIPTION
**Description**

Set the `HAVE_DEVICEMONITOR` environment variable as required by https://github.com/mendersoftware/mender-server-enterprise/pull/642