### PR TITLE
chore(workflows): remove HAVE_DEVICEMONITOR workflow env variable

### DIFF
--- a/mender/templates/workflows/_podtemplate.yaml
+++ b/mender/templates/workflows/_podtemplate.yaml
@@ -125,10 +125,6 @@ spec:
     - name: HAVE_DEVICECONFIG
       value: "true"
     {{- end }}
-    {{- if .dot.Values.devicemonitor.enabled }}
-    - name: HAVE_DEVICEMONITOR
-      value: "true"
-    {{- end }}
     {{- end }}
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.workflows) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
 


### PR DESCRIPTION
**Description**
This PR reverts https://github.com/mendersoftware/mender-helm/pull/529. 
See https://github.com/mendersoftware/mender-server-enterprise/pull/642 for more information.