### PR TITLE
feat: added inventory addr to tenantadm pod template

### DIFF
--- a/mender/templates/tenantadm/_podtemplate.yaml
+++ b/mender/templates/tenantadm/_podtemplate.yaml
@@ -89,6 +89,8 @@ spec:
       value: {{ printf "http://%s:%v" .dot.Values.deployments.service.name .dot.Values.deployments.service.port | quote }}
     - name: TENANTADM_DEVICEAUTH_ADDR
       value: {{ printf "http://%s:%v" .dot.Values.device_auth.service.name .dot.Values.device_auth.service.port | quote }}
+    - name: TENANTADM_INVENTORY_ADDR
+      value: {{ printf "http://%s:%v" .dot.Values.inventory.service.name .dot.Values.inventory.service.port | quote }}
     - name: TENANTADM_ORCHESTRATOR_ADDR
       value: {{ printf "http://%s:%v" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
     - name: TENANTADM_USERADM_ADDR


### PR DESCRIPTION
**Description**
Added `INVENTORY_ADDR` to the tenantadm podtemplate as a result of the dependency introduced in https://github.com/mendersoftware/mender-server-enterprise/pull/1124

Ticket: MEN-9470