### PR TITLE
ci: switch test container images to per-image registry paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  PIPELINE_TOOLBOX_IMAGE: "registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master"
+  PIPELINE_TOOLBOX_IMAGE: "registry.gitlab.com/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master"
   EKS_CLUSTER_NAME: "helmci-${CI_PIPELINE_ID}"
   RUN_HELM_CHART_INSTALL:
     value: "false"
@@ -767,7 +767,7 @@ cleanup_eks_cluster:failed:manual:
   <<: *eks_cleanup
 
 changelog:
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
   stage: changelog
   variables:
     GIT_DEPTH: 0 # Always get the full history
@@ -824,7 +824,7 @@ changelog:
     - git remote remove github-${CI_JOB_ID}
 
 release:github:
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
   stage: .post
   tags:
     - hetzner-amd-beefy


### PR DESCRIPTION
## Summary

Migrates mender-test-containers image references from the legacy flat-tag format to the new per-image sub-repository format:

- `mender-test-containers:aws-k8s-v1-master` → `mender-test-containers/aws-k8s-toolbox:master`
- `mender-test-containers:release-please-v1-master` → `mender-test-containers/release-please:master`

Part of epic QA-1597.

## Test plan

- [ ] CI pipeline passes on this branch
- [ ] All affected jobs pull images successfully from the new registry paths

Ticket: QA-1602, QA-1609