### PR TITLE
ci: replace test:kubeconform_tests with unified test:kubeconform job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -470,9 +470,9 @@ test:helm_chart_upgrade_from_current_lts_to_current_release:
     - echo "INFO - cleaning up resources"
     - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
 
-test:kubeconform_tests:
+test:kubeconform:
   tags:
-    - hetzner-amd-beefy
+    - k8s-small
   image: ${PIPELINE_TOOLBOX_IMAGE}
   stage: test
   rules:
@@ -482,35 +482,9 @@ test:kubeconform_tests:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
-  id_tokens:
-    AWS_OIDC_TOKEN:
-      aud: https://gitlab.com
-  before_script:
-    - *set_eks_helmci_vars
+    - when: on_success
   script:
-    - |
-      echo "INFO - running kubeconform tests:"
-      while IFS= read -r version; do
-        full_version=${version}.0
-        echo "INFO - testing version ${full_version}"
-        helm template mender/ \
-          -f tests/values-helmci.yaml \
-          --kube-version ${full_version} \
-        | kubeconform --kubernetes-version ${full_version}
-      done < <(eksctl version -o json | jq -r '.EKSServerSupportedVersions[]')
-    - |
-      echo "DEBUG - run failed kubeconform tests: this should fail"
-      sed -i 's/apps\/v1/fakeapps\/v42/' mender/templates/gui/deployment.yaml
-      while IFS= read -r version; do
-        full_version=${version}.0
-        echo "INFO - testing version ${full_version}"
-        helm template mender/ \
-          -f tests/values-helmci.yaml \
-          --kube-version ${full_version} \
-        | kubeconform --kubernetes-version ${full_version} \
-        || echo "INFO - test failed with version ${kubeversion}: this is expected"
-      done < <(eksctl version -o json | jq -r '.EKSServerSupportedVersions[]')
+    - make kubeconform
 
 test:helm_unittest:
   tags:


### PR DESCRIPTION
Drop the EKS-dependent kubeconform job (hetzner runner, AWS OIDC, eksctl version discovery) and replace it with a single lightweight job that runs on every branch including MRs.

Key changes:
- runner: hetzner-amd-beefy -> k8s-small
- rules: it runs on all branches
- version source: eksctl EKS list -> endoflife.date public API (5 most recent non-EOL Kubernetes minor versions, no auth)
- validation flags: added --strict --ignore-missing-schemas

Co-authored-with: Claude