### PR TITLE
ci: correct amount of cpu requested in the tests

### DIFF
--- a/tests/values-helmci.yaml
+++ b/tests/values-helmci.yaml
@@ -36,8 +36,8 @@ generate_delta_worker:
     enabled: false
   resources:
     limits:
-      cpu: 50
+      cpu: 50m
       memory: 100Mi
     requests:
-      cpu: 50
+      cpu: 50m
       memory: 100Mi


### PR DESCRIPTION
Not full cores, but millicores