### PR TITLE
CI fix: prevent helm namespace fallback on k8s runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,6 +106,8 @@ renovate:
     - k8s-small
 
 .set_eks_helmci_vars: &set_eks_helmci_vars
+  # prevent client-go in-cluster fallback to the runner pod namespace
+  - unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
   - export AWS_DEFAULT_REGION=eu-central-1
   - >
     export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"


### PR DESCRIPTION
Jobs running on the k8s runners execute inside a pod with the in-cluster service env vars set. When the EKS kubeconfig context has no explicit namespace, client-go falls back to the runner pod namespace (gitlab-runner), which does not exist on the target EKS cluster, breaking helm install of cert-manager. Unset KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT in the shared EKS vars anchor to disable the in-cluster detection.

Co-authored-with: Claude