### PR TITLE
ci: fix CloudFormation stack deletion failures on EKS cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,9 +126,15 @@ renovate:
     --output text))
   - aws sts get-caller-identity
 
+.post_test_helm_cleanup: &post_test_helm_cleanup
+  - |
+    echo "INFO - cleaning up all Helm releases in namespace ${NAMESPACE}"
+    helm list -n "${NAMESPACE}" -q 2>/dev/null \
+      | xargs -r helm delete -n "${NAMESPACE}" --timeout 5m || true
+
 .pre_helm_tests: &pre_helm_tests
   - eksctl utils write-kubeconfig --cluster=${EKS_CLUSTER_NAME}
-  - kubectl create ns "${NAMESPACE}"
+  - kubectl create ns "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
   - kubectl config set-context --current --namespace="${NAMESPACE}"
   - echo "INFO - installing helm from scratch"
   - aws ecr get-login-password --region eu-central-1 | helm registry login --username AWS --password-stdin ${ECR_REGISTRY}
@@ -138,7 +144,8 @@ renovate:
       --docker-username=${REGISTRY_MENDER_IO_USERNAME} \
       --docker-password=${REGISTRY_MENDER_IO_PASSWORD} \
       --docker-email=${REGISTRY_MENDER_IO_EMAIL} \
-      --docker-server=registry.mender.io
+      --docker-server=registry.mender.io \
+      --dry-run=client -o yaml | kubectl apply -f -
 
 build:setup_eks_cluster:
   image: ${PIPELINE_TOOLBOX_IMAGE}
@@ -296,8 +303,7 @@ test:helm_chart_install:
         ./mender || exit 3;
     - make test
   after_script:
-    - echo "INFO - cleaning up to save resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 test:helm_chart_install_sub_charts:
   tags:
@@ -362,8 +368,7 @@ test:helm_chart_install_sub_charts:
       bash tests/ingress-internal-test.sh
     - bash tests/ci-test-teardown.sh || true
   after_script:
-    - echo "INFO - cleaning up resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 .test:helm_chart_upgrade_from_previous_lts_to_current_lts: # TODO: enable this for the next LTS
   # For example: from Mender 3.6 to Mender 3.7
@@ -427,8 +432,7 @@ test:helm_chart_install_sub_charts:
     - helm history mender
     - make test
   after_script:
-    - echo "INFO - cleaning up resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 test:helm_chart_upgrade_from_current_lts_to_current_release:
   tags:
@@ -489,8 +493,7 @@ test:helm_chart_upgrade_from_current_lts_to_current_release:
     - helm history mender
     - make test
   after_script:
-    - echo "INFO - cleaning up resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 test:kubeconform:
   tags:
@@ -615,8 +618,7 @@ test:helm_chart_install_opensource:
       bash tests/ingress-internal-test.sh
     - bash tests/ci-test-teardown.sh || true
   after_script:
-    - echo "INFO - cleaning up to save resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 test:helm_chart_install_with_r2:
   tags:
@@ -685,8 +687,7 @@ test:helm_chart_install_with_r2:
       bash tests/ingress-internal-test.sh
     - bash tests/ci-test-teardown.sh || true
   after_script:
-    - echo "INFO - cleaning up resources"
-    - helm delete -n "${NAMESPACE}" mender || exit 0 # if it fails it means it's timing out - not that important
+    - *post_test_helm_cleanup
 
 test:playground_eks_cluster:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ build:setup_eks_cluster:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG || $RUN_PLAYGROUND == "true"'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG || $RUN_PLAYGROUND == "true"'
   id_tokens:
     AWS_OIDC_TOKEN:
       aud: https://gitlab.com
@@ -271,7 +271,7 @@ test:helm_chart_install:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-setup-test"
   id_tokens:
@@ -316,7 +316,7 @@ test:helm_chart_install_sub_charts:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-setup-test-sub-charts"
     INSTALL_SEAWEEDFS_DEP_ONLY: "true"
@@ -383,7 +383,7 @@ test:helm_chart_install_sub_charts:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-upgrade-test-previous-tls"
   id_tokens:
@@ -448,7 +448,7 @@ test:helm_chart_upgrade_from_current_lts_to_current_release:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-upgrade-test-current-lts"
   id_tokens:
@@ -569,7 +569,7 @@ test:helm_chart_install_opensource:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-opensource-setup-test"
     INSTALL_SEAWEEDFS_DEP_ONLY: "true"
@@ -638,7 +638,7 @@ test:helm_chart_install_with_r2:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG'
   variables:
     NAMESPACE: "mender-setup-test-r2"
   id_tokens:
@@ -760,7 +760,7 @@ publish:helm_chart_publishing:
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "master-next" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG || $RUN_PLAYGROUND == "true"'
+    - if: '$CI_COMMIT_REF_PROTECTED == "true" || $RUN_HELM_CHART_INSTALL == "true" || $CI_COMMIT_TAG || $RUN_PLAYGROUND == "true"'
   id_tokens:
     AWS_OIDC_TOKEN:
       aud: https://gitlab.com

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,116 @@ renovate:
     --output text))
   - aws sts get-caller-identity
 
+.delete_ecr_inline_policy: &delete_ecr_inline_policy
+  - |
+    echo "INFO - removing ecr-pull-through-cache inline policy from node role"
+    NODEGROUP=$(eksctl get nodegroup --cluster ${EKS_CLUSTER_NAME} -o json 2>/dev/null | jq -r '.[0].Name // empty')
+    if [ -z "$NODEGROUP" ]; then
+      echo "INFO - no nodegroup found, skipping inline policy deletion"
+    else
+      NODE_ROLE_ARN=$(aws eks describe-nodegroup \
+        --cluster-name ${EKS_CLUSTER_NAME} \
+        --nodegroup-name "${NODEGROUP}" \
+        --query 'nodegroup.nodeRole' --output text 2>/dev/null || true)
+      NODE_ROLE_NAME=$(basename "${NODE_ROLE_ARN}")
+      aws iam delete-role-policy \
+        --role-name "${NODE_ROLE_NAME}" \
+        --policy-name "ecr-pull-through-cache" || true
+    fi
+
+.pre_eks_delete_cleanup: &pre_eks_delete_cleanup
+  - |
+    echo "INFO - writing kubeconfig for pre-deletion cleanup"
+    eksctl utils write-kubeconfig --cluster=${EKS_CLUSTER_NAME} || true
+  - |
+    echo "INFO - deleting Helm releases in application namespaces (kube-system preserved so LB controller stays up)"
+    for ns in $(kubectl get ns --no-headers -o custom-columns=':metadata.name' 2>/dev/null | grep -v '^kube-system$'); do
+      releases=$(helm list -n "$ns" -q 2>/dev/null)
+      if [ -n "$releases" ]; then
+        echo "INFO - deleting releases in namespace $ns: $releases"
+        echo "$releases" | xargs -r helm delete -n "$ns" --timeout 5m || true
+      fi
+    done
+  - |
+    echo "INFO - draining ELBs from cluster VPC"
+    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
+      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
+    if [ -n "$VPC_ID" ]; then
+      for i in $(seq 1 9); do
+        LB_COUNT=$(aws elbv2 describe-load-balancers \
+          --query "length(LoadBalancers[?VpcId=='${VPC_ID}'])" \
+          --output text 2>/dev/null || echo 0)
+        [ "${LB_COUNT:-0}" -eq 0 ] && echo "INFO - no ELBs remaining" && break
+        echo "INFO - ${LB_COUNT} ELB(s) still present (attempt $i/9), waiting 10s..."
+        sleep 10
+      done
+      LB_ARNS=$(aws elbv2 describe-load-balancers \
+        --query "LoadBalancers[?VpcId=='${VPC_ID}'].LoadBalancerArn" \
+        --output json 2>/dev/null | jq -r '.[]' || true)
+      if [ -n "$LB_ARNS" ]; then
+        for arn in $LB_ARNS; do
+          echo "INFO - force-deleting ELB: $arn"
+          aws elbv2 delete-load-balancer --load-balancer-arn "$arn" || true
+        done
+        for arn in $LB_ARNS; do
+          aws elbv2 wait load-balancers-deleted --load-balancer-arns "$arn" || true
+        done
+      fi
+    fi
+  - |
+    echo "INFO - sweeping all available ENIs in cluster VPC (up to 3m, then force-delete)"
+    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
+      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
+    if [ -n "$VPC_ID" ]; then
+      for i in $(seq 1 18); do
+        ENI_COUNT=$(aws ec2 describe-network-interfaces \
+          --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
+          --query 'length(NetworkInterfaces)' \
+          --output text 2>/dev/null || echo 0)
+        [ "${ENI_COUNT:-0}" -eq 0 ] && echo "INFO - no available ENIs remaining" && break
+        echo "INFO - ${ENI_COUNT} available ENI(s) in VPC (attempt $i/18), waiting 10s..."
+        sleep 10
+      done
+      ENI_IDS=$(aws ec2 describe-network-interfaces \
+        --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
+        --query 'NetworkInterfaces[].NetworkInterfaceId' \
+        --output json 2>/dev/null | jq -r '.[]' || true)
+      for eni in $ENI_IDS; do
+        echo "INFO - force-deleting available ENI: $eni"
+        aws ec2 delete-network-interface --network-interface-id "$eni" || true
+      done
+    fi
+  - |
+    echo "INFO - deleting Load Balancer Controller security groups"
+    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
+      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
+    if [ -n "$VPC_ID" ]; then
+      LB_SGS=$(aws ec2 describe-security-groups \
+        --filters \
+          "Name=vpc-id,Values=${VPC_ID}" \
+          "Name=tag:elbv2.k8s.aws/cluster,Values=${EKS_CLUSTER_NAME}" \
+        --query 'SecurityGroups[].GroupId' \
+        --output json 2>/dev/null | jq -r '.[]' || true)
+      for sg in $LB_SGS; do
+        REFS=$(aws ec2 describe-security-groups \
+          --filters "Name=vpc-id,Values=${VPC_ID}" "Name=ip-permission.group-id,Values=${sg}" \
+          --query 'SecurityGroups[].GroupId' \
+          --output json 2>/dev/null | jq -r '.[]' || true)
+        for ref in $REFS; do
+          PERMS=$(aws ec2 describe-security-groups --group-ids "$ref" \
+            --query "SecurityGroups[0].IpPermissions[?UserIdGroupPairs[?GroupId=='${sg}']]" \
+            --output json 2>/dev/null || echo '[]')
+          [ "$PERMS" != "[]" ] && aws ec2 revoke-security-group-ingress \
+            --group-id "$ref" --ip-permissions "$PERMS" || true
+        done
+        echo "INFO - deleting security group: $sg"
+        aws ec2 delete-security-group --group-id "$sg" || true
+      done
+    fi
+  - |
+    echo "INFO - deleting Helm releases in kube-system"
+    helm list -n kube-system -q 2>/dev/null | xargs -r helm delete -n kube-system --timeout 5m || true
+
 .post_test_helm_cleanup: &post_test_helm_cleanup
   - |
     echo "INFO - cleaning up all Helm releases in namespace ${NAMESPACE}"
@@ -751,7 +861,6 @@ publish:helm_chart_publishing:
   tags:
     - k8s
   resource_group: helm
-  allow_failure: true # can't find a way to avoid eks cleanup when no eks is setup, so let's allow to fail for now
   dependencies:
     - build:setup_eks_cluster
   rules:
@@ -768,8 +877,16 @@ publish:helm_chart_publishing:
   before_script:
     - *set_eks_helmci_vars
   script:
-    - echo "INFO - deleting the temporary EKS cluster"
-    - eksctl delete cluster -n ${EKS_CLUSTER_NAME}
+    - *delete_ecr_inline_policy
+    - *pre_eks_delete_cleanup
+    - |
+      echo "INFO - checking if cluster ${EKS_CLUSTER_NAME} exists before deletion"
+      if eksctl get cluster --name ${EKS_CLUSTER_NAME} > /dev/null 2>&1; then
+        echo "INFO - deleting the temporary EKS cluster"
+        eksctl delete cluster -n ${EKS_CLUSTER_NAME}
+      else
+        echo "INFO - cluster ${EKS_CLUSTER_NAME} not found, skipping deletion"
+      fi
 
 cleanup_eks_cluster:failed:
   when: on_failure

--- a/tests/ci-make-deps.sh
+++ b/tests/ci-make-deps.sh
@@ -34,7 +34,7 @@ else
         oci://${ECR_DOCKERHUB_MIRROR}/bitnamicharts/mongodb \
         --version 16.5.45 \
         --set "global.security.allowInsecureImages=true" \
-        --set "global.imageRegistry=${ECR_REGISTRY}" \
+        --set "image.registry=${ECR_REGISTRY}" \
         --set "image.repository=dockerhub/bitnamisecure/mongodb" \
         --set "image.tag=latest" \
         --set "auth.enabled=false" \


### PR DESCRIPTION
The cleanup jobs were leaving orphaned CloudFormation stacks because:
- The ecr-pull-through-cache inline IAM policy added to the node role during cluster setup was never removed before eksctl delete cluster, causing CloudFormation to fail deleting the node IAM role.
- The AWS Load Balancer Controller provisioned ELBs outside CloudFormation; deleting the cluster without first removing Helm releases left those ELBs attached to the VPC subnets, blocking VPC deletion.
- allow_failure: true on the cleanup jobs silently absorbed all failures.

Fix by adding three new YAML anchors:
- delete_ecr_inline_policy: removes the inline policy via aws iam before the cluster is torn down.
- pre_eks_delete_cleanup: iterates all namespaces, deletes all Helm releases, and waits 60s for ELB deprovisioning before eksctl runs.
- post_test_helm_cleanup: replaces the per-job after_script that only deleted the mender release; now deletes all releases in the namespace (seaweedfs, mender-mongo, nats, and mender).

Replace allow_failure: true with an explicit eksctl get cluster existence check so cleanup failures are surfaced rather than swallowed.


Co-Authored-with: Claude