### PR TITLE
chore: add base url for devicemonitor, needed for security email sending

### DIFF
--- a/mender/templates/devicemonitor/_podtemplate.yaml
+++ b/mender/templates/devicemonitor/_podtemplate.yaml
@@ -77,6 +77,8 @@ spec:
       value: {{ printf "http://%s:%v" .dot.Values.useradm.service.name .dot.Values.useradm.service.port | quote }}
     - name: DEVICEMONITOR_WORKFLOWS_URL
       value: {{ printf "http://%s:%v" .dot.Values.workflows.service.name .dot.Values.workflows.service.port | quote }}
+    - name: DEVICEMONITOR_BASE_URL
+      value: {{ .dot.Values.global.url | quote }}
 
     {{- include "mender.customEnvs" (merge (deepCopy .dot.Values.devicemonitor) (deepCopy (default (dict) .dot.Values.default))) | nindent 4 }}
 


### PR DESCRIPTION
chore: add base url for devicemonitor, needed for security email sending

Devicemonitor now uses the general email notification template
and this setting is needed, see QA-1646 and
mender-server-enterprise/ed22c191630e06e9410e9c29ad214639027118c4

Ticket: QA-1646
Signed-off-by: Peter Grzybowski <peter@northern.tech>