### PR TITLE
CICD tests - VPC delete failed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,10 +142,37 @@ renovate:
         --policy-name "ecr-pull-through-cache" || true
     fi
 
+.sweep_available_enis: &sweep_available_enis
+  - |
+    if [ -n "$VPC_ID" ] && [ "$VPC_ID" != "None" ]; then
+      for i in $(seq 1 18); do
+        ENI_COUNT=$(aws ec2 describe-network-interfaces \
+          --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
+          --query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 0)
+        [ "${ENI_COUNT:-0}" -eq 0 ] && echo "INFO - no available ENIs remaining" && break
+        echo "INFO - ${ENI_COUNT} available ENI(s) in VPC ${VPC_ID} (attempt $i/18), waiting 10s..."
+        sleep 10
+      done
+      ENI_IDS=$(aws ec2 describe-network-interfaces \
+        --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
+        --query 'NetworkInterfaces[].NetworkInterfaceId' --output json 2>/dev/null | jq -r '.[]' || true)
+      for eni in $ENI_IDS; do
+        echo "INFO - force-deleting available ENI: $eni"
+        aws ec2 delete-network-interface --network-interface-id "$eni" || true
+      done
+    else
+      echo "INFO - VPC_ID not resolved, skipping ENI sweep"
+    fi
+
 .pre_eks_delete_cleanup: &pre_eks_delete_cleanup
   - |
     echo "INFO - writing kubeconfig for pre-deletion cleanup"
     eksctl utils write-kubeconfig --cluster=${EKS_CLUSTER_NAME} || true
+  - |
+    echo "INFO - resolving cluster VPC"
+    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
+      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
+    echo "INFO - cluster VPC: ${VPC_ID:-<none>}"
   - |
     echo "INFO - deleting Helm releases in application namespaces (kube-system preserved so LB controller stays up)"
     for ns in $(kubectl get ns --no-headers -o custom-columns=':metadata.name' 2>/dev/null | grep -v '^kube-system$'); do
@@ -157,8 +184,6 @@ renovate:
     done
   - |
     echo "INFO - draining ELBs from cluster VPC"
-    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
-      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
     if [ -n "$VPC_ID" ]; then
       for i in $(seq 1 9); do
         LB_COUNT=$(aws elbv2 describe-load-balancers \
@@ -183,31 +208,9 @@ renovate:
     fi
   - |
     echo "INFO - sweeping all available ENIs in cluster VPC (up to 3m, then force-delete)"
-    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
-      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
-    if [ -n "$VPC_ID" ]; then
-      for i in $(seq 1 18); do
-        ENI_COUNT=$(aws ec2 describe-network-interfaces \
-          --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
-          --query 'length(NetworkInterfaces)' \
-          --output text 2>/dev/null || echo 0)
-        [ "${ENI_COUNT:-0}" -eq 0 ] && echo "INFO - no available ENIs remaining" && break
-        echo "INFO - ${ENI_COUNT} available ENI(s) in VPC (attempt $i/18), waiting 10s..."
-        sleep 10
-      done
-      ENI_IDS=$(aws ec2 describe-network-interfaces \
-        --filters "Name=vpc-id,Values=${VPC_ID}" "Name=status,Values=available" \
-        --query 'NetworkInterfaces[].NetworkInterfaceId' \
-        --output json 2>/dev/null | jq -r '.[]' || true)
-      for eni in $ENI_IDS; do
-        echo "INFO - force-deleting available ENI: $eni"
-        aws ec2 delete-network-interface --network-interface-id "$eni" || true
-      done
-    fi
+  - *sweep_available_enis
   - |
     echo "INFO - deleting Load Balancer Controller security groups"
-    VPC_ID=$(aws eks describe-cluster --name ${EKS_CLUSTER_NAME} \
-      --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)
     if [ -n "$VPC_ID" ]; then
       LB_SGS=$(aws ec2 describe-security-groups \
         --filters \
@@ -896,12 +899,23 @@ publish:helm_chart_publishing:
     - *pre_eks_delete_cleanup
     - |
       echo "INFO - checking if cluster ${EKS_CLUSTER_NAME} exists before deletion"
-      if eksctl get cluster --name ${EKS_CLUSTER_NAME} > /dev/null 2>&1; then
-        echo "INFO - deleting the temporary EKS cluster"
-        eksctl delete cluster -n ${EKS_CLUSTER_NAME}
-      else
+      if ! eksctl get cluster --name ${EKS_CLUSTER_NAME} > /dev/null 2>&1; then
         echo "INFO - cluster ${EKS_CLUSTER_NAME} not found, skipping deletion"
+        exit 0
       fi
+    - |
+      echo "INFO - deleting nodegroups first"
+      eksctl delete nodegroup --cluster ${EKS_CLUSTER_NAME} --all --wait || true
+      echo "INFO - post-nodegroup-teardown ENI sweep"
+    - *sweep_available_enis
+    - |
+      echo "INFO - deleting the temporary EKS cluster (control plane + VPC), attempt 1/2"
+      eksctl delete cluster -n ${EKS_CLUSTER_NAME} && exit 0
+      echo "WARN - eksctl delete cluster failed, re-sweeping ENIs and retrying once"
+    - *sweep_available_enis
+    - |
+      echo "INFO - deleting the temporary EKS cluster (control plane + VPC), attempt 2/2"
+      eksctl delete cluster -n ${EKS_CLUSTER_NAME}
 
 cleanup_eks_cluster:failed:
   when: on_failure

--- a/tests/ingress-internal-test.sh
+++ b/tests/ingress-internal-test.sh
@@ -38,7 +38,7 @@ n=0
 max_wait=512
 while [ $n -lt $max_wait ]; do
     sleep 1
-    LB_IP=$(dig +short ${LB_HOSTNAME} @1.1.1.1 | head -n1)
+    LB_IP=$(dig +short +time=2 +tries=1 ${LB_HOSTNAME} @1.1.1.1 2>/dev/null | grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}$' | head -n1)
     if [ -n "${LB_IP}" ] ; then
         echo -e "\n> LB IP is ready: ${LB_IP}"
         break


### PR DESCRIPTION
This PR addresses:
* Frequent NIC orphaned causes VPC deletion failure and dangling VPCs are causing the next jobs to fail
* properly retry DNS during LB bootstrap

Co-authored-with: Claude