### PR TITLE
:construction: pull staging enterprise images directly from ECR

### DIFF
--- a/mender/values-staging.yaml
+++ b/mender/values-staging.yaml
@@ -1,67 +1,67 @@
 auditlogs:
   image:
     tag: main@sha256:430d024923679d535a94ff43c8fc8c837c12c87b54d5db7d30e1e46a81b5a9bd
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 deployments:
   image:
     tag: main@sha256:36110d863f7b5e45c69215cc26faa8a5296f53630f936e8641b66f9cc9cabe1b
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 inventory:
   image:
     tag: main@sha256:c08c7cabf4e605c99b56782202146f25f8dbaf292298b2d54711817de70fed92
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 create_artifact_worker:
   image:
     tag: main@sha256:c90afffae87b1afb6fc04680a2d18267ab41f09e614b2d04dbe41693ed85a1cc
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 generate_delta_worker:
   image:
     tag: main@sha256:48377f8458796330b66e4aa3f0d92115ad207dce88e9a3f008624c81797a2b81
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 deviceconnect:
   image:
     tag: main@sha256:e91231232bd59a1ebbaf90e9a4c9d3518a98cf957a6450a6d16bd5969c1e933f
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 device_auth:
   image:
     tag: main@sha256:f0e9874353b7fcf338cac6eb9a0fef7b29d3c14970f6d0f58b167bf91a818abd
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 tenantadm:
   image:
     tag: main@sha256:e1d0d78c8f0b9b5df252c3623a8bf86111cf208044e189681267209bd8936f1e
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 devicemonitor:
   image:
     tag: main@sha256:ba1aa8f83aec806df70113802aa52c2b671574f928ed2ad338b62d589a92af0f
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 useradm:
   image:
     tag: main@sha256:cae3f962d7d402225e2cb0777e5e6cec0f4f14eb954e37bee921cda6cb3c27f8
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 deviceconfig:
   image:
     tag: main@sha256:fee85d9b608844873452f2d0dc8af87f02b19ed26ee4e268949250af9209f370
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 iot_manager:
   image:
     tag: main@sha256:2f18acd6a5ed404155abfa8b5bbcdd21b58bfcbd0884c3f3c9a63a1e0df74103
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 workflows:
   image:
     tag: main@sha256:0a4c961d929c3176864c4067ff81dece5094b48b6a63baaf8e06c8ce3a9fea58
-    registry: registry.mender.io
+    registry: 017659451055.dkr.ecr.eu-central-1.amazonaws.com
     repository: mender-server-enterprise
 gui:
   image:


### PR DESCRIPTION
Point the staging enterprise service images at the ECR registry instead of registry.mender.io, so the cluster pulls with the node role and drops the me-proxy. The gui image (docker.io) is unchanged.

Ticket: MC-7956

:warning: requires the following PRs to be approved and merged first:
* :construction: 