### PR TITLE
ci: only run renovate on its own pipeline schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,9 @@ default:
 renovate:
   needs: []
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    # Only the renovate schedule sets this. Without it renovate also ran on the
+    # other schedules in this project.
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_SCHEDULED_RUN == "true"'
     - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
   stage: build
   tags:


### PR DESCRIPTION
Part of QA-1734

This repo defines its renovate job locally rather than using the mendertesting renovate component, so the gate going into mendersoftware/mendertesting#525 does not reach it. Same one line condition applied here directly

The rule was `$CI_PIPELINE_SOURCE == "schedule"` which matches any scheduled pipeline. Gitlab does not say which schedule started a pipeline, so renovate ran on the other schedules in this project too, not just its own

The renovate schedule already has RENOVATE_SCHEDULED_RUN=true set, so this takes effect immediately on merge. The manual FORCE_RENOVATE_RUN path is untouched

Worth a separate cleanup later - this repo hand writes the renovate job against the upstream renovate-runner component instead of using ours, which is why the fix had to be duplicated here
