### PR TITLE
feat: added the rewritten admin panel to the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,96 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.lifecycle` | Container [lifecycle](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) hooks. Default preStop sleep gives the load balancer time to deregister the pod before SIGTERM. | `{"preStop":{"sleep":{"seconds":30}}}` |
 | `api_gateway.terminationGracePeriodSeconds` | [Pod termination grace period](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination). Must cover preStop sleep + drain time. | `60` |
 
+### Parameters: admin-panel
+
+The admin panel is an internal Northern.tech tool. It is disabled by default and requires
+`global.enterprise`. It drives the privileged internal endpoints of the other services, so both its
+sudo API and its GUI are published only on `admin_panel.hostname` - a host of its own, so the panel
+session cookie never rides along on customer-facing requests. Setting the hostname is mandatory:
+without it the api-gateway routers stay unrendered and the chart fails to render.
+
+`admin_panel.ingress` is a dedicated Ingress for that host, separate from `ingress`. It defaults to
+the internal AWS ALB group, so the panel is not reachable from the public listener the rest of the
+API shares. Deployments on another ingress controller have to override both `ingressClassName` and
+`annotations`.
+
+`ADMIN_PANEL_BASE_URL` is derived from `admin_panel.hostname`, because the OAuth `redirect_uri` is
+built from it and a wrong value only surfaces as a `redirect_uri` mismatch at the identity provider
+on the first sign in.
+
+The following table lists the parameters for the `admin_panel` component and their default values:
+
+| Parameter | Description | Default |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `admin_panel.enabled` | Enable the component | `false` |
+| `admin_panel.hostname` | Host serving both the panel GUI and the sudo API, for example `admin.mender.example.com`. Required when the component is enabled | `""` |
+| `admin_panel.replicas` | Number of replicas, ignored when an HPA is active | `1` |
+| `admin_panel.image.registry` | Docker image registry | `registry.mender.io` |
+| `admin_panel.image.repository` | Docker image repository | `mender-server-enterprise` |
+| `admin_panel.image.tag` | Docker image tag | `nil`, falls back to the chart `appVersion` |
+| `admin_panel.image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `admin_panel.existingSecret` | Existing secret providing `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` and `SESSION_SECRET`. The keys are read with an `ADMIN_PANEL_` prefix | `""` |
+| `admin_panel.customEnvs` | Custom environment variables, for example `ADMIN_PANEL_ALLOWED_EMAIL_DOMAINS` | `[]` |
+| `admin_panel.ingress.enabled` | Create a dedicated Ingress for `admin_panel.hostname` | `false` |
+| `admin_panel.ingress.ingressClassName` | Ingress class of the dedicated Ingress | `alb` |
+| `admin_panel.ingress.annotations` | Ingress annotations, default to the internal ALB group `mender-internal` with `scheme: internal` | see `values.yaml` |
+| `admin_panel.ingress.path` | Path of the dedicated Ingress, the whole host belongs to the panel | `/` |
+| `admin_panel.ingress.extraPaths` | Extra Ingress paths inserted ahead of the api-gateway backend, for example the ALB `ssl-redirect` action | `[]` |
+| `admin_panel.ingress.tls` | TLS configuration of the dedicated Ingress | `[]` |
+| `admin_panel.service.name` | Service name | `mender-admin-panel` |
+| `admin_panel.service.type` | Service type | `ClusterIP` |
+| `admin_panel.service.port` | Service port | `8080` |
+| `admin_panel.service.annotations` | Service annotations | `{}` |
+| `admin_panel.resources.limits.cpu` | Resources CPU limit | `50m` |
+| `admin_panel.resources.limits.memory` | Resources memory limit | `128Mi` |
+| `admin_panel.resources.requests.cpu` | Resources CPU request | `50m` |
+| `admin_panel.resources.requests.memory` | Resources memory request | `128Mi` |
+| `admin_panel.hpa` | HorizontalPodAutoscaler overrides, see `default.hpa` | `{}` |
+| `admin_panel.probesOverrides` | Override the properties of the readiness, liveness and startup probes | `{}` |
+| `admin_panel.podAnnotations` | Pod annotations | `{}` |
+| `admin_panel.podSecurityContext` | Pod security context, disabled by default | `enabled: false` |
+| `admin_panel.containerSecurityContext` | Container security context, disabled by default | `enabled: false` |
+| `admin_panel.affinity` | Affinity rules, falls back to `default.affinity` | `{}` |
+| `admin_panel.nodeSelector` | Node selector, falls back to `default.nodeSelector` | `{}` |
+| `admin_panel.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
+| `admin_panel.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `""` |
+| `admin_panel.updateStrategy` | The strategy to use to update existing pods | `nil` |
+
+### Parameters: admin-panel-gui
+
+The GUI is served from the root of `admin_panel.hostname`, so it shares an origin with the sudo API.
+
+The following table lists the parameters for the `admin_panel_gui` component and their default values:
+
+| Parameter | Description | Default |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `admin_panel_gui.enabled` | Enable the component, requires `admin_panel.enabled` | `false` |
+| `admin_panel_gui.replicas` | Number of replicas, ignored when an HPA is active | `1` |
+| `admin_panel_gui.image.registry` | Docker image registry | `registry.mender.io` |
+| `admin_panel_gui.image.repository` | Docker image repository | `mender-server-enterprise` |
+| `admin_panel_gui.image.tag` | Docker image tag | `nil`, falls back to the chart `appVersion` |
+| `admin_panel_gui.image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `admin_panel_gui.httpPort` | Port the GUI container listens on | `8090` |
+| `admin_panel_gui.service.name` | Service name | `mender-admin-panel-gui` |
+| `admin_panel_gui.service.type` | Service type | `ClusterIP` |
+| `admin_panel_gui.service.port` | Service port | `80` |
+| `admin_panel_gui.service.annotations` | Service annotations | `{}` |
+| `admin_panel_gui.resources.limits.cpu` | Resources CPU limit | `20m` |
+| `admin_panel_gui.resources.limits.memory` | Resources memory limit | `64Mi` |
+| `admin_panel_gui.resources.requests.cpu` | Resources CPU request | `5m` |
+| `admin_panel_gui.resources.requests.memory` | Resources memory request | `16Mi` |
+| `admin_panel_gui.customEnvs` | Custom environment variables | `[]` |
+| `admin_panel_gui.hpa` | HorizontalPodAutoscaler overrides, see `default.hpa` | `{}` |
+| `admin_panel_gui.probesOverrides` | Override the properties of the readiness, liveness and startup probes | `initialDelaySeconds: 2`, `periodSeconds: 5` |
+| `admin_panel_gui.podAnnotations` | Pod annotations | `{}` |
+| `admin_panel_gui.podSecurityContext` | Pod security context, disabled by default | `enabled: false` |
+| `admin_panel_gui.containerSecurityContext` | Container security context, disabled by default | `enabled: false` |
+| `admin_panel_gui.affinity` | Affinity rules, falls back to `default.affinity` | `{}` |
+| `admin_panel_gui.nodeSelector` | Node selector, falls back to `default.nodeSelector` | `{}` |
+| `admin_panel_gui.imagePullSecrets` | Optional list of existing Image Pull Secrets in the format of `- name: my-custom-secret` | `[]` |
+| `admin_panel_gui.priorityClassName` | Optional pre-existing priorityClassName to be assigned to the resource | `""` |
+| `admin_panel_gui.updateStrategy` | The strategy to use to update existing pods | `nil` |
+
 ### Parameters: deployments
 
 The following table lists the parameters for the `deployments` component and their default values:

--- a/mender/templates/_helpers.tpl
+++ b/mender/templates/_helpers.tpl
@@ -156,6 +156,22 @@ nats_conf_validation - fail on conflicting NATS configuration
 {{- end }}
 
 {{/*
+admin_panel_conf_validation - fail on an admin panel that cannot work as configured
+*/}}
+{{- define "admin_panel_conf_validation" }}
+{{- $dot := (ternary . .dot (empty .dot)) -}}
+{{- if and $dot.Values.admin_panel.enabled (empty $dot.Values.admin_panel.hostname) }}
+{{- fail "admin_panel.hostname is required: the panel is only routed on a host of its own" }}
+{{- end }}
+{{- if and $dot.Values.admin_panel_gui.enabled (not $dot.Values.admin_panel.enabled) }}
+{{- fail "admin_panel_gui.enabled requires admin_panel.enabled: the GUI has no backend to talk to" }}
+{{- end }}
+{{- if and $dot.Values.admin_panel.enabled (empty $dot.Values.admin_panel.existingSecret) (empty $dot.Values.admin_panel.customEnvs) }}
+{{- fail "admin_panel needs OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET and SESSION_SECRET: set admin_panel.existingSecret or admin_panel.customEnvs" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Ingress rules
 */}}
 {{- define "mender.serviceName" -}}

--- a/mender/templates/admin-panel-gui/deployment.yaml
+++ b/mender/templates/admin-panel-gui/deployment.yaml
@@ -1,0 +1,110 @@
+{{- if and .Values.admin_panel_gui.enabled .Values.global.enterprise }}
+{{- include "admin_panel_conf_validation" . }}
+{{- $context := dict "dot" . "component" "admin-panel-gui" "override" .Values.admin_panel_gui -}}
+{{- $merged := merge (deepCopy .Values.admin_panel_gui) (deepCopy (default (dict) .Values.default)) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mender.fullname" . }}-admin-panel-gui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel-gui
+    app.kubernetes.io/component: admin-panel-gui
+spec:
+  {{- if not (or .Values.admin_panel_gui.hpa .Values.default.hpa ) }}
+  replicas: {{ .Values.admin_panel_gui.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel-gui
+
+  progressDeadlineSeconds: 600
+
+  {{- $updateStrategy := coalesce .Values.admin_panel_gui.updateStrategy .Values.default.updateStrategy }}
+  {{- if $updateStrategy }}
+  strategy: {{- toYaml $updateStrategy | nindent 4 }}
+  {{- end }}
+
+  {{- $minReadySeconds := coalesce .Values.admin_panel_gui.minReadySeconds .Values.default.minReadySeconds }}
+  {{- if $minReadySeconds }}
+  minReadySeconds: {{ $minReadySeconds }}
+  {{- end }}
+
+  template:
+    metadata:
+      {{- with .Values.admin_panel_gui.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel-gui
+        {{- include "mender.labels" . | nindent 8 }}
+        app.kubernetes.io/component: admin-panel-gui
+    spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
+      {{- with $merged.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with $merged.tolerations }}
+      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+{{- if .Values.admin_panel_gui.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.admin_panel_gui.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
+
+      containers:
+      - name: admin-panel-gui
+        image: {{ include "mender.image" $context }}
+        imagePullPolicy: {{ include "mender.imagePullPolicy" $context }}
+{{- if .Values.admin_panel_gui.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.admin_panel_gui.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
+        {{- with include "mender.resources" (list .Values.default.resources .Values.admin_panel_gui.resources) }}
+        resources: {{- nindent 10 . }}
+        {{- end }}
+
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.admin_panel_gui.httpPort }}
+          {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.admin_panel_gui.probesOverrides ) }}
+          {{- nindent 10 . }}
+          {{- end }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.admin_panel_gui.httpPort }}
+          {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.admin_panel_gui.probesOverrides ) }}
+          {{- nindent 10 . }}
+          {{- end }}
+        startupProbe:
+          tcpSocket:
+            port: {{ .Values.admin_panel_gui.httpPort }}
+          {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.admin_panel_gui.probesOverrides ) }}
+          {{- nindent 10 . }}
+          {{- end }}
+
+        {{- with include "mender.customEnvs" (merge (deepCopy .Values.admin_panel_gui) (deepCopy (default (dict) .Values.default))) }}
+        env:
+        {{- nindent 8 . }}
+        {{- end }}
+
+{{- if and .Values.global.image .Values.global.image.username }}
+      imagePullSecrets:
+      - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.admin_panel_gui.imagePullSecrets .Values.default.imagePullSecrets }}
+{{- if $ips }}
+      imagePullSecrets:
+{{- toYaml $ips | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{- $pcn := coalesce .Values.admin_panel_gui.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end }}
+
+{{- with (coalesce .Values.admin_panel_gui.nodeSelector .Values.default.nodeSelector) }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/mender/templates/admin-panel-gui/hpa.yaml
+++ b/mender/templates/admin-panel-gui/hpa.yaml
@@ -1,0 +1,5 @@
+{{- if and .Values.admin_panel_gui.enabled .Values.global.enterprise }}
+{{- $servicename := "admin-panel-gui" }}
+{{- $context := (dict "default" .Values.default "override" .Values.admin_panel_gui "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.autoscaler" $context }}
+{{- end }}

--- a/mender/templates/admin-panel-gui/service.yaml
+++ b/mender/templates/admin-panel-gui/service.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.admin_panel_gui.enabled .Values.global.enterprise }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.admin_panel_gui.service.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: admin-panel-gui-svc
+    app.kubernetes.io/component: admin-panel-gui
+{{- with .Values.admin_panel_gui.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.admin_panel_gui.service.type }}
+  {{- if and (eq .Values.admin_panel_gui.service.type "ClusterIP") .Values.admin_panel_gui.service.clusterIP }}
+  clusterIP: {{ .Values.admin_panel_gui.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.admin_panel_gui.service.type "LoadBalancer") .Values.admin_panel_gui.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin_panel_gui.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.admin_panel_gui.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.admin_panel_gui.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.admin_panel_gui.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.admin_panel_gui.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.admin_panel_gui.service.port }}
+    name: http
+    protocol: TCP
+    targetPort: {{ .Values.admin_panel_gui.httpPort }}
+    {{- if .Values.admin_panel_gui.service.nodePort }}
+    nodePort: {{ .Values.admin_panel_gui.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel-gui
+{{- end }}

--- a/mender/templates/admin-panel/deployment.yaml
+++ b/mender/templates/admin-panel/deployment.yaml
@@ -1,0 +1,137 @@
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise }}
+{{- include "admin_panel_conf_validation" . }}
+{{- $context := dict "dot" . "component" "admin-panel" "override" .Values.admin_panel -}}
+{{- $merged := merge (deepCopy .Values.admin_panel) (deepCopy (default (dict) .Values.default)) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mender.fullname" . }}-admin-panel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel
+    app.kubernetes.io/component: admin-panel
+spec:
+  {{- if not (or .Values.admin_panel.hpa .Values.default.hpa ) }}
+  replicas: {{ .Values.admin_panel.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel
+
+  progressDeadlineSeconds: 600
+
+  {{- $updateStrategy := coalesce .Values.admin_panel.updateStrategy .Values.default.updateStrategy }}
+  {{- if $updateStrategy }}
+  strategy: {{- toYaml $updateStrategy | nindent 4 }}
+  {{- end }}
+
+  {{- $minReadySeconds := coalesce .Values.admin_panel.minReadySeconds .Values.default.minReadySeconds }}
+  {{- if $minReadySeconds }}
+  minReadySeconds: {{ $minReadySeconds }}
+  {{- end }}
+
+  template:
+    metadata:
+      {{- with .Values.admin_panel.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel
+        {{- include "mender.labels" . | nindent 8 }}
+        app.kubernetes.io/component: admin-panel
+    spec:
+      serviceAccountName: {{ include "mender.serviceAccountName" . }}
+      {{- with $merged.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with $merged.tolerations }}
+      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+{{- if .Values.admin_panel.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.admin_panel.podSecurityContext "enabled" | toYaml | nindent 8 }}
+{{- end }}
+
+      containers:
+      - name: admin-panel
+        image: {{ include "mender.image" $context }}
+        imagePullPolicy: {{ include "mender.imagePullPolicy" $context }}
+{{- if .Values.admin_panel.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.admin_panel.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+{{- end }}
+        {{- with include "mender.resources" (list .Values.default.resources .Values.admin_panel.resources) }}
+        resources: {{- nindent 10 . }}
+        {{- end }}
+
+        args: ["server"]
+
+        readinessProbe:
+          httpGet:
+            path: /api/internal/v1/admin-panel/health
+            port: 8080
+          periodSeconds: 15
+          {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.admin_panel.probesOverrides ) }}
+          {{- nindent 10 . }}
+          {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /api/internal/v1/admin-panel/alive
+            port: 8080
+          periodSeconds: 5
+          {{- with include "mender.probesOverrides" (dict "default" .Values.default.probesOverrides "override" .Values.admin_panel.probesOverrides ) }}
+          {{- nindent 10 . }}
+          {{- end }}
+        startupProbe:
+          httpGet:
+            path: /api/internal/v1/admin-panel/alive
+            port: 8080
+          failureThreshold: 36
+          periodSeconds: 5
+
+        env:
+        - name: ADMIN_PANEL_BASE_URL
+          value: {{ printf "https://%s" .Values.admin_panel.hostname | quote }}
+        - name: ADMIN_PANEL_TENANTADM_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.tenantadm.service.name .Values.tenantadm.service.port }}
+        - name: ADMIN_PANEL_USERADM_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.useradm.service.name .Values.useradm.service.port }}
+        - name: ADMIN_PANEL_DEVICEAUTH_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.device_auth.service.name .Values.device_auth.service.port }}
+        - name: ADMIN_PANEL_DEPLOYMENTS_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.deployments.service.name .Values.deployments.service.port }}
+        - name: ADMIN_PANEL_INVENTORY_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.inventory.service.name .Values.inventory.service.port }}
+        # the chart names the workflows service '-server', so the service default of 'mender-workflows' does not resolve here
+        - name: ADMIN_PANEL_WORKFLOWS_ADDRESS
+          value: {{ printf "http://%s:%v" .Values.workflows.service.name .Values.workflows.service.port }}
+        {{- include "mender.customEnvs" (merge (deepCopy .Values.admin_panel) (deepCopy (default (dict) .Values.default))) | nindent 8 }}
+        # The OAuth credentials and the session secret have no defaults and the  service refuses to start without them,
+        # so they are expected to come in through customEnvs or the secret below.
+        {{- with .Values.admin_panel.existingSecret }}
+        envFrom:
+        - prefix: ADMIN_PANEL_
+          secretRef:
+            name: {{ . }}
+        {{- end }}
+
+{{- if and .Values.global.image .Values.global.image.username }}
+      imagePullSecrets:
+      - name: docker-registry
+{{- else }}
+{{- $ips := coalesce .Values.admin_panel.imagePullSecrets .Values.default.imagePullSecrets }}
+{{- if $ips }}
+      imagePullSecrets:
+{{- toYaml $ips | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{- $pcn := coalesce .Values.admin_panel.priorityClassName .Values.global.priorityClassName -}}
+{{- if $pcn }}
+      priorityClassName: {{ $pcn }}
+{{- end }}
+
+{{- with (coalesce .Values.admin_panel.nodeSelector .Values.default.nodeSelector) }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/mender/templates/admin-panel/hpa.yaml
+++ b/mender/templates/admin-panel/hpa.yaml
@@ -1,0 +1,5 @@
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise }}
+{{- $servicename := "admin-panel" }}
+{{- $context := (dict "default" .Values.default "override" .Values.admin_panel "name" (printf "%s-%s" (include "mender.fullname" . ) $servicename ) ) -}}
+{{- include "mender.autoscaler" $context }}
+{{- end }}

--- a/mender/templates/admin-panel/ingress.yaml
+++ b/mender/templates/admin-panel/ingress.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise .Values.admin_panel.ingress.enabled -}}
+{{- include "admin_panel_conf_validation" . }}
+{{- $fullName := include "mender.serviceName" . -}}
+{{- $servicePort := .Values.api_gateway.service.httpPort -}}
+{{- $ingressExtraPaths := .Values.admin_panel.ingress.extraPaths -}}
+{{- $ingressSupportsIngressClassName := eq (include "mender.ingress.supportsIngressClassName" .) "true" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}-admin-panel-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin-panel
+{{- with .Values.admin_panel.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.admin_panel.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.admin_panel.ingress.ingressClassName }}
+  {{- end -}}
+{{- with .Values.admin_panel.ingress.tls }}
+  tls:
+  {{- range . }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+    # the backend is the api-gateway, not the panel services: traefik does the
+    # host and path split so the sudo api and the gui keep a single origin
+    - host: {{ .Values.admin_panel.hostname | quote }}
+      http:
+        paths:
+          {{- range $ingressExtraPaths }}
+          - path: {{ .path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .backend.serviceName }}
+                port:
+                {{- if .backend.servicePort }}
+                  name: {{ .backend.servicePort }}
+                {{- else }}
+                  number: {{ .backend.servicePortNumber }}
+                {{- end }}
+          {{- end }}
+          - path: {{ .Values.admin_panel.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- else }}
+    - host: {{ .Values.admin_panel.hostname | quote }}
+      http:
+        paths:
+          {{- range $ingressExtraPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .backend.serviceName }}
+              servicePort: {{ .backend.servicePort | default .backend.servicePortNumber }}
+          {{- end }}
+          - path: {{ .Values.admin_panel.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}

--- a/mender/templates/admin-panel/service.yaml
+++ b/mender/templates/admin-panel/service.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.admin_panel.service.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mender.labels" . | nindent 4 }}
+    app.kubernetes.io/name: admin-panel-svc
+    app.kubernetes.io/component: admin-panel
+{{- with .Values.admin_panel.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.admin_panel.service.type }}
+  {{- if and (eq .Values.admin_panel.service.type "ClusterIP") .Values.admin_panel.service.clusterIP }}
+  clusterIP: {{ .Values.admin_panel.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.admin_panel.service.type "LoadBalancer") .Values.admin_panel.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin_panel.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.admin_panel.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.admin_panel.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.admin_panel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.admin_panel.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.admin_panel.service.port }}
+    name: http
+    protocol: TCP
+    targetPort: 8080
+    {{- if .Values.admin_panel.service.nodePort }}
+    nodePort: {{ .Values.admin_panel.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "mender.fullname" . }}-admin-panel
+{{- end }}

--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -41,6 +41,52 @@ data:
           service: ping@internal
           priority: 20
 
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise .Values.admin_panel.hostname }}
+        adminPanel:
+          entrypoints: {{ $scheme }}
+          middlewares:
+          - ratelimit
+          - adminPanelHeaders
+          - sec-headers
+{{- if .Values.api_gateway.compression }}
+          - compression
+{{- end }}
+          rule: "Host(`{{ .Values.admin_panel.hostname }}`) && PathRegexp(`^/api/sudo/v[0-9a-z]+/admin-panel`)"
+          service: admin-panel
+          priority: 100
+          tls: {{ $isTls }}
+{{- if .Values.api_gateway.authRateLimit }}
+        adminPanelAuth:
+          entrypoints: {{ $scheme }}
+          middlewares:
+          - authRateLimit
+          - adminPanelHeaders
+          - sec-headers
+{{- if .Values.api_gateway.compression }}
+          - compression
+{{- end }}
+          rule: "Host(`{{ .Values.admin_panel.hostname }}`) && PathRegexp(`^/api/sudo/v[0-9a-z]+/admin-panel/auth`)"
+          service: admin-panel
+          priority: 110
+          tls: {{ $isTls }}
+{{- end }}
+{{- end }}
+{{- if and .Values.admin_panel_gui.enabled .Values.global.enterprise .Values.admin_panel.hostname }}
+        adminPanelGui:
+          entrypoints: {{ $scheme }}
+          middlewares:
+          - ratelimit
+          - adminPanelHeaders
+          - sec-headers
+{{- if .Values.api_gateway.compression }}
+          - compression
+{{- end }}
+          rule: "Host(`{{ .Values.admin_panel.hostname }}`)"
+          service: admin-panel-gui
+          priority: 15
+          tls: {{ $isTls }}
+{{- end }}
+
         #
         # auditlogs
         #
@@ -401,6 +447,20 @@ data:
       #
       services:
 
+{{- if and .Values.admin_panel.enabled .Values.global.enterprise }}
+        admin-panel:
+          loadBalancer:
+            servers:
+            - url: "http://{{ .Values.admin_panel.service.name }}:{{ .Values.admin_panel.service.port }}"
+{{- end }}
+{{- if and .Values.admin_panel_gui.enabled .Values.global.enterprise }}
+
+        admin-panel-gui:
+          loadBalancer:
+            servers:
+            - url: "http://{{ .Values.admin_panel_gui.service.name }}:{{ .Values.admin_panel_gui.service.port }}"
+{{- end }}
+
         auditlogs:
           loadBalancer:
             servers:
@@ -525,6 +585,16 @@ data:
         authRateLimit:
           ratelimit:
 {{ toYaml .Values.api_gateway.authRateLimit | indent 12 }}
+{{- end }}
+
+{{- if and (or .Values.admin_panel.enabled .Values.admin_panel_gui.enabled) .Values.global.enterprise .Values.admin_panel.hostname }}
+        adminPanelHeaders:
+          headers:
+            customRequestHeaders:
+              X-MEN-RequestID: ""
+              X-MEN-RBAC-Inventory-Groups: ""
+              X-MEN-RBAC-Deployments-Groups: ""
+              X-MEN-RBAC-Releases-Tags: ""
 {{- end }}
 
         devauth:

--- a/mender/tests/admin-panel_test.yaml
+++ b/mender/tests/admin-panel_test.yaml
@@ -1,0 +1,275 @@
+suite: test admin panel gating, validation and host based gateway routing
+templates:
+  - templates/admin-panel/deployment.yaml
+  - templates/admin-panel/ingress.yaml
+  - templates/admin-panel-gui/deployment.yaml
+  - templates/api-gateway/configmap.yaml
+tests:
+  - it: should render nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel/deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel/ingress.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel-gui/deployment.yaml
+
+  - it: should render nothing when enabled on an open source install
+    set:
+      global.enterprise: false
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      admin_panel.ingress.enabled: true
+      admin_panel_gui.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel/deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel/ingress.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/admin-panel-gui/deployment.yaml
+
+  # nothing routes the panel without a hostname, so an enabled panel without one
+  # is rejected for the whole chart rather than deployed unreachable
+  - it: should fail when no hostname is set
+    template: templates/admin-panel/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "admin_panel.hostname is required: the panel is only routed on a host of its own"
+
+  - it: should fail when the gui is enabled without the backend
+    template: templates/admin-panel-gui/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel_gui.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "admin_panel_gui.enabled requires admin_panel.enabled: the GUI has no backend to talk to"
+
+  - it: should fail when no credentials are provided
+    template: templates/admin-panel/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+    asserts:
+      - failedTemplate:
+          errorMessage: "admin_panel needs OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET and SESSION_SECRET: set admin_panel.existingSecret or admin_panel.customEnvs"
+
+  - it: should accept credentials from customEnvs instead of a secret
+    template: templates/admin-panel/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.customEnvs:
+        - name: ADMIN_PANEL_SESSION_SECRET
+          value: secret
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should default the base url to the admin host
+    template: templates/admin-panel/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="ADMIN_PANEL_BASE_URL")].value
+          value: https://admin.docker.mender.io
+
+  - it: should wire the backend to the internal service addresses
+    template: templates/admin-panel/deployment.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="ADMIN_PANEL_WORKFLOWS_ADDRESS")].value
+          value: http://mender-workflows-server:8080
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: admin-panel-secret
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].prefix
+          value: ADMIN_PANEL_
+
+  - it: should not route the admin panel unless it is enabled
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+    asserts:
+      - notMatchRegex:
+          path: data["traefik.yaml"]
+          pattern: "admin-panel"
+
+  - it: should serve the whole admin host from the gui
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      admin_panel_gui.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'rule: "Host\(`admin\.docker\.mender\.io`\)"'
+      - notMatchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'PathPrefix\(`/admin`\)'
+      # above the catch-all gui router and below healthz, so /healthz survives on
+      # the admin host when both share the http entrypoint
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'rule: "Host\(`admin\.docker\.mender\.io`\)"\n\s+service: admin-panel-gui\n\s+priority: 15'
+
+  - it: should host scope the sudo api
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'rule: "Host\(`admin\.docker\.mender\.io`\) && PathRegexp\(`\^/api/sudo/v\[0-9a-z\]\+/admin-panel`\)"'
+      # no sudo route may ever be reachable on the customer facing host
+      - notMatchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'rule: "PathRegexp\(`\^/api/sudo'
+
+  - it: should not render a duplicate auth router when authRateLimit is unset
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      api_gateway.authRateLimit: ~
+    asserts:
+      - notMatchRegex:
+          path: data["traefik.yaml"]
+          pattern: "adminPanelAuth"
+
+  - it: should render the auth router with its own rate limit when authRateLimit is set
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      api_gateway.authRateLimit:
+        average: 10
+        burst: 20
+    asserts:
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: "adminPanelAuth"
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: "priority: 110"
+
+  - it: should strip client supplied X-MEN headers on the admin routes
+    template: templates/api-gateway/configmap.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: '\n\s+- adminPanelHeaders\n'
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'X-MEN-RBAC-Inventory-Groups: ""'
+      # the list has to track useradm's authResponseHeaders or a spoofed header
+      # reaches the panel unfiltered
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'X-MEN-RequestID: ""'
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'X-MEN-RBAC-Deployments-Groups: ""'
+      - matchRegex:
+          path: data["traefik.yaml"]
+          pattern: 'X-MEN-RBAC-Releases-Tags: ""'
+
+  - it: should render an internal ingress for the admin host
+    template: templates/admin-panel/ingress.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      admin_panel.ingress.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: admin.docker.mender.io
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/scheme"]
+          value: internal
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/group.name"]
+          value: mender-internal
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: mender-api-gateway
+
+  # the default annotations keep :80 open, so the alb ssl-redirect action has to
+  # be wireable the same way it is on the main ingress
+  - it: should put extraPaths ahead of the api-gateway backend
+    template: templates/admin-panel/ingress.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+      admin_panel.ingress.enabled: true
+      admin_panel.ingress.extraPaths:
+        - path: /
+          backend:
+            serviceName: ssl-redirect
+            servicePort: use-annotation
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: ssl-redirect
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: use-annotation
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: mender-api-gateway
+
+  - it: should not render the admin ingress when the panel is enabled but the ingress is not
+    template: templates/admin-panel/ingress.yaml
+    set:
+      global.enterprise: true
+      admin_panel.enabled: true
+      admin_panel.hostname: admin.docker.mender.io
+      admin_panel.existingSecret: admin-panel-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -1529,6 +1529,144 @@ devicemonitor:
     # successThreshold: 2
     # failureThreshold: 6
 
+# The admin panel is an internal, Northern.tech only tool: it drives the
+# privileged endpoints of the other services, so it stays off unless a
+# deployment asks for it explicitly.
+admin_panel:
+  enabled: false
+  hostname: ""
+  podAnnotations: {}
+  replicas: 1
+  resources:
+    limits:
+      cpu: 50m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+  affinity: {}
+  # image:
+  #   registry: ""
+  #   repository: ""
+  #   tag: ""
+  #   pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  nodeSelector: {}
+  service:
+    name: mender-admin-panel
+    annotations: {}
+    type: ClusterIP
+    port: 8080
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
+  priorityClassName: ""
+
+  ingress:
+    enabled: false
+    ingressClassName: alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internal
+      alb.ingress.kubernetes.io/group.name: mender-internal
+      alb.ingress.kubernetes.io/group.order: "50"
+      alb.ingress.kubernetes.io/backend-protocol: HTTP
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      alb.ingress.kubernetes.io/success-codes: 200-499
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+      alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+      alb.ingress.kubernetes.io/healthcheck-path: /
+    path: /
+    extraPaths: []
+    # - path: /
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
+    tls: []
+    # - secretName: mender-admin-panel-ingress-tls
+    #   hosts:
+    #     - admin.mender.example.com
+
+  # The service refuses to start without OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET
+  # and SESSION_SECRET, so this - or customEnvs - has to provide them.
+  existingSecret: ""
+
+  customEnvs: []
+  # - name: ADMIN_PANEL_ALLOWED_EMAIL_DOMAINS
+  #   value: northern.tech
+
+  # updateStrategy:
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
+
+  probesOverrides:
+    {}
+    # timeoutSeconds: 2
+    # successThreshold: 2
+    # failureThreshold: 6
+
+  hpa: {}
+
+admin_panel_gui:
+  enabled: false
+  podAnnotations: {}
+  replicas: 1
+  resources:
+    limits:
+      cpu: 20m
+      memory: 64Mi
+    requests:
+      cpu: 5m
+      memory: 16Mi
+  affinity: {}
+  # image:
+  #   registry: ""
+  #   repository: ""
+  #   tag: ""
+  #   pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  nodeSelector: {}
+  service:
+    name: mender-admin-panel-gui
+    annotations: {}
+    type: ClusterIP
+    port: 80
+  httpPort: 8090
+  podSecurityContext:
+    enabled: false
+    runAsNonRoot: true
+    runAsUser: 65534
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
+    runAsUser: 65534
+  priorityClassName: ""
+
+  customEnvs: []
+  # - name: LOG_LEVEL
+  #   value: DEBUG
+
+  # updateStrategy:
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
+
+  probesOverrides:
+    initialDelaySeconds: 2
+    periodSeconds: 5
+    # timeoutSeconds: 2
+    # successThreshold: 2
+    # failureThreshold: 6
+
+  hpa: {}
+
 # This is a sample redis deployment single instance included in the
 # helm chart for convinence. Not recommended in production.
 redis:
@@ -1592,4 +1730,3 @@ dbmigration:
     enabled: false
     runAsNonRoot: true
     runAsUser: 999
-


### PR DESCRIPTION
- backend is published on the /api/sudo/v1/admin-panel prefix only
- the gui is under /admin
- disabled by default as it's an internal tool

needs https://github.com/mendersoftware/mender-server-enterprise/pull/1600