### PR TITLE
feat(redis): new limits and requests for cpu

### DIFF
--- a/mender/values.yaml
+++ b/mender/values.yaml
@@ -1557,11 +1557,11 @@ redis:
 
   resources:
     limits:
-      memory: "512Mi"
-      cpu: "500m"
+      memory: "1024Mi"
+      cpu: "1500m"
     requests:
-      memory: "256Mi"
-      cpu: "100m"
+      memory: "512Mi"
+      cpu: "800m"
 
   securityContext:
     enabled: true

--- a/tests/values-helmci.yaml
+++ b/tests/values-helmci.yaml
@@ -29,6 +29,13 @@ redis:
   replica:
     persistence:
       enabled: false
+  resources:
+    limits:
+      cpu: 1500m
+      memory: 1100Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
 
 generate_delta_worker:
   enabled: true


### PR DESCRIPTION
pods show:
Limits:
      cpu:     100m
      memory:  64Mi
    Requests:
      cpu:     10m
      memory:  32Mi

I am uncertain if those limits are passed as we want them. See also: https://northern-tech.slack.com/archives/xxx/p1788491966744309

based on top pod:
mender-redis-cluster-0                           73m          610Mi
mender-redis-cluster-1                           267m         630Mi
mender-redis-cluster-2                           104m         617Mi
mender-redis-cluster-3                           255m         618Mi
mender-redis-cluster-4                           407m         679Mi
mender-redis-cluster-5                           97m          592Mi

and then after 0.5 hour:
mender-redis-cluster-0                           73m          611Mi
mender-redis-cluster-1                           264m         630Mi
mender-redis-cluster-2                           102m         617Mi
mender-redis-cluster-3                           256m         619Mi
mender-redis-cluster-4                           334m         615Mi
mender-redis-cluster-5                           312m         594Mi

Changelog: Title
Ticket: None