### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,16 +57,6 @@ variables:
     options:
       - "true"
       - "false"
-  # Renovate required variables
-  RENOVATE_PLATFORM: github
-  RENOVATE_ENDPOINT: "https://api.github.com"
-  RENOVATE_GIT_AUTHOR: "mender-test-bot <mender@northern.tech>"
-  RENOVATE_TOKEN: $GITHUB_BOT_TOKEN_REPO_FULL
-  RENOVATE_GITHUB_COM_TOKEN: $GITHUB_BOT_TOKEN_REPO_FULL
-  RENOVATE_REPOSITORIES: "mendersoftware/$CI_PROJECT_NAME"
-  RENOVATE_REQUIRE_CONFIG: "optional"
-  RENOVATE_ONBOARDING: "false"
-  RENOVATE_GIT_PRIVATE_KEY: $SSH_PRIVATE_KEY
   FORCE_RENOVATE_RUN:
     description: "Force a renovate bot run"
     value: "false"
@@ -94,21 +84,10 @@ include:
     file: ".gitlab-ci-github-status-updates.yml"
   - project: "Northern.tech/Mender/mendertesting"
     file: ".gitlab-ci-check-helm-version-bump.yml"
-  - component: gitlab.com/renovate-bot/renovate-runner/renovate.gitlab-ci@main
 
 default:
   tags: !reference [.qa-common-default-runner, tags]
   retry: !reference [.qa-common-default-retry, retry]
-
-# Override rules
-renovate:
-  needs: []
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "web" && $FORCE_RENOVATE_RUN == "true"'
-  stage: build
-  tags:
-    - k8s-small
 
 .set_eks_helmci_vars: &set_eks_helmci_vars
   # prevent client-go in-cluster fallback to the runner pod namespace


### PR DESCRIPTION
This repo was missed when the renovate job was removed from the other repos. It uses the upstream renovate-runner component directly rather than the mendertesting wrapper, so the search for the wrapper did not match it.

Renovate runs centrally from NorthernTechHQ/renovate-ring now and this repo has its own renovate.json5, so it is currently covered twice. The renovate job here has no condition beyond CI_PIPELINE_SOURCE == schedule, and the Weekly schedule on Tuesday still fires it, so it really is running.

Removes the component include, the job override and the RENOVATE_ variables.

Two things left alone on purpose. FORCE_RENOVATE_RUN and the fifteen guards referencing it are now dead but harmless, and touching that many rules in this file is not worth the risk in the same change. The Weekly schedule looks like it exists only for renovate, since every other job has schedule when never, so it can probably go too but that is your call.