### PR TITLE
feat: add a dedicated rate limit for the artifact list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The following table lists the parameters for the `api-gateway` component and the
 | `api_gateway.rateLimit.sourceCriterion` | See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `{"ipStrategy": {"depth": 1}}` |
 | `api_gateway.extraArgs` | Optional list of additional args for the `api_gateway` container. | `null` |
 | `api_gateway.authRateLimit` | Optional rate limiting for the Auth module only. See the [Traefik rate limit configuration options](https://doc.traefik.io/traefik/v2.6/middlewares/http/ratelimit/#configuration-options) | `null` |
+| `api_gateway.artifactsListRateLimit` | Optional rate limiting for `GET /api/management/v{n}/deployments/artifacts` only. | `null` |
 | `api_gateway.podSecurityContext.enabled` | Enable [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `false` |
 | `api_gateway.podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
 | `api_gateway.podSecurityContext.runAsUser` | User ID for the pod | `65534` |

--- a/mender/templates/api-gateway/configmap.yaml
+++ b/mender/templates/api-gateway/configmap.yaml
@@ -144,6 +144,22 @@ data:
           service: deployments
           tls: {{ $isTls }}
 
+{{- if .Values.api_gateway.artifactsListRateLimit }}
+        deploymentsArtifactsList:
+          entrypoints: {{ $scheme }}
+          priority: 100
+          middlewares:
+          - artifactsListRateLimit
+          - userauth
+          - sec-headers
+{{- if .Values.api_gateway.compression }}
+          - compression
+{{- end }}
+          rule: "Method(`GET`) && PathRegexp(`^/api/management/v[0-9a-z]+/deployments/artifacts$`)"
+          service: deployments
+          tls: {{ $isTls }}
+{{- end }}
+
         deploymentsMgmt:
           entrypoints: {{ $scheme }}
           middlewares:
@@ -585,6 +601,12 @@ data:
         authRateLimit:
           ratelimit:
 {{ toYaml .Values.api_gateway.authRateLimit | indent 12 }}
+{{- end }}
+
+{{- if .Values.api_gateway.artifactsListRateLimit }}
+        artifactsListRateLimit:
+          ratelimit:
+{{ toYaml .Values.api_gateway.artifactsListRateLimit | indent 12 }}
 {{- end }}
 
 {{- if and (or .Values.admin_panel.enabled .Values.admin_panel_gui.enabled) .Values.global.enterprise .Values.admin_panel.hostname }}


### PR DESCRIPTION
GET /api/management/v[0-9a-z]+/deployments/artifacts returns a large response body and is cheap to poll. The general per-IP ratelimit middleware counts requests, not bytes, so at its configured 50 req/s it authorises roughly 6.4 MB/s from a single client on this route.

Add an optional artifactsListRateLimit middleware and a dedicated router for that path, following the existing authRateLimit pattern. The router takes priority 100 so it wins over deploymentsMgmt, which matches the same prefix by rule length.

The rule is anchored, so artifacts/list, artifacts/{id} and the POST upload path are unaffected and keep the general ratelimit.

Both blocks are rendered only when api_gateway.artifactsListRateLimit is set, so the chart is unchanged for anyone who does not configure it.

Ticket: MC-8877

Co-authored-with: Claude